### PR TITLE
fix(frontend): replace remaining native selects with the themed Dropdown

### DIFF
--- a/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/appointments/components/FrontDeskBoard.test.tsx
@@ -176,7 +176,8 @@ describe('FrontDeskBoard', () => {
       />
     );
 
-    await user.selectOptions(screen.getByLabelText('Assign room'), 'room-2');
+    await user.click(screen.getByRole('button', { name: /Assign room/ }));
+    await user.click(within(screen.getByRole('listbox')).getByText('Exam 2'));
     expect(props.onAssignRoom).toHaveBeenCalledWith('7', 'room-2');
   });
 
@@ -220,7 +221,8 @@ describe('FrontDeskBoard', () => {
 
     await user.click(screen.getByLabelText('Patient'));
     await user.click(screen.getByRole('option', { name: 'Bruno — Sarah' }));
-    await user.selectOptions(screen.getByLabelText('Triage priority'), 'IMMEDIATE');
+    await user.click(screen.getByRole('button', { name: /Triage priority/ }));
+    await user.click(within(screen.getByRole('listbox')).getByText('Immediate'));
     await user.click(screen.getByRole('button', { name: 'Check in patient' }));
 
     expect(props.onAdd).toHaveBeenCalledWith(
@@ -264,7 +266,7 @@ describe('FrontDeskBoard', () => {
     );
   });
 
-  it('ignores selecting the placeholder in the room control', async () => {
+  it('does not offer a blank option to clear an assigned room', async () => {
     const user = userEvent.setup();
     const props = handlers();
     render(
@@ -275,7 +277,8 @@ describe('FrontDeskBoard', () => {
       />
     );
 
-    await user.selectOptions(screen.getByLabelText('Assign room'), '');
+    await user.click(screen.getByRole('button', { name: /Assign room/ }));
+    expect(within(screen.getByRole('listbox')).queryByText('Assign room')).not.toBeInTheDocument();
     expect(props.onAssignRoom).not.toHaveBeenCalled();
   });
 

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/AllergyList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/AllergyList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import AllergyList from '@/app/features/companionHistory/components/AllergyList';
@@ -100,8 +100,10 @@ describe('AllergyList', () => {
     expect(allergenInput).toBeInTheDocument();
 
     await userEvent.type(allergenInput, 'Latex');
-    await userEvent.selectOptions(screen.getByLabelText('Type'), 'ENVIRONMENTAL');
-    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'SEVERE');
+    await userEvent.click(screen.getByRole('button', { name: /Type/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Environmental'));
+    await userEvent.click(screen.getByRole('button', { name: /Severity/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Severe'));
     await userEvent.type(screen.getByLabelText('Reaction'), 'Contact dermatitis');
     fireEvent.change(screen.getByLabelText('Onset date'), { target: { value: '2026-02-01' } });
     await userEvent.type(screen.getByLabelText('Notes'), 'Gloves only');

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/AllergyListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/AllergyListPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { isAuthRedirectError } from '@/app/services/axios';
@@ -105,8 +105,10 @@ describe('AllergyListPanel', () => {
 
     await userEvent.click(screen.getByRole('button', { name: /Add allergy/ }));
     await userEvent.type(screen.getByLabelText('Allergen'), 'Latex');
-    await userEvent.selectOptions(screen.getByLabelText('Type'), 'ENVIRONMENTAL');
-    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'MODERATE');
+    await userEvent.click(screen.getByRole('button', { name: /Type/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Environmental'));
+    await userEvent.click(screen.getByRole('button', { name: /Severity/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Moderate'));
     await userEvent.type(screen.getByLabelText('Reaction'), 'Dermatitis');
     await userEvent.type(screen.getByLabelText('Notes'), 'Gloves only');
     fireEvent.change(screen.getByLabelText('Onset date'), { target: { value: '2026-02-01' } });

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ConsentList from '@/app/features/companionHistory/components/ConsentList';
@@ -128,7 +128,8 @@ describe('ConsentList', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
 
-    await userEvent.selectOptions(screen.getByLabelText('Consent type'), 'DIAGNOSTIC');
+    await userEvent.click(screen.getByRole('button', { name: /Consent type/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Diagnostic'));
     await userEvent.type(screen.getByLabelText('Procedure'), 'Abdominal ultrasound');
     await userEvent.type(screen.getByLabelText('Consented by'), 'Sam Owner');
     fireEvent.change(screen.getByLabelText('Expiry date'), { target: { value: '2026-06-01' } });

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/ConsentListPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { isAuthRedirectError } from '@/app/services/axios';
@@ -131,7 +131,8 @@ describe('ConsentListPanel', () => {
     await screen.findByText(/No consents recorded/);
 
     await userEvent.click(screen.getByRole('button', { name: 'Record consent' }));
-    await userEvent.selectOptions(screen.getByLabelText('Consent type'), 'DIAGNOSTIC');
+    await userEvent.click(screen.getByRole('button', { name: /Consent type/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Diagnostic'));
     await userEvent.type(screen.getByLabelText('Procedure'), 'Abdominal ultrasound');
     await userEvent.type(screen.getByLabelText('Consented by'), '  Sam Owner  ');
     fireEvent.change(screen.getByLabelText('Expiry date'), { target: { value: '2026-06-01' } });

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagList.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import FlagList from '@/app/features/companionHistory/components/FlagList';
@@ -75,8 +75,10 @@ describe('FlagList', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
     await userEvent.type(screen.getByLabelText('Flag title'), '  Needs quiet room  ');
-    await userEvent.selectOptions(screen.getByLabelText('Flag type'), 'ANXIETY');
-    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'HIGH');
+    await userEvent.click(screen.getByRole('button', { name: /Flag type/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Anxiety'));
+    await userEvent.click(screen.getByRole('button', { name: /Severity/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('High'));
     await userEvent.type(screen.getByLabelText('Description'), 'Dim the lights');
     await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
 

--- a/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagListPanel.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/companionHistory/components/FlagListPanel.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { isAuthRedirectError } from '@/app/services/axios';
@@ -91,8 +91,10 @@ describe('FlagListPanel', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Add flag' }));
     await userEvent.type(screen.getByLabelText('Flag title'), 'Use side entrance');
-    await userEvent.selectOptions(screen.getByLabelText('Flag type'), 'ESCAPE_RISK');
-    await userEvent.selectOptions(screen.getByLabelText('Severity'), 'HIGH');
+    await userEvent.click(screen.getByRole('button', { name: /Flag type/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Escape risk'));
+    await userEvent.click(screen.getByRole('button', { name: /Severity/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('High'));
     await userEvent.type(screen.getByLabelText('Description'), '  Keep both doors closed  ');
     await userEvent.click(screen.getByRole('button', { name: 'Save flag' }));
 

--- a/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceRegister.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/compliance/ControlledSubstanceRegister.test.tsx
@@ -178,8 +178,10 @@ describe('ControlledSubstanceRegister', () => {
     const form = screen.getByRole('form', { name: 'Add controlled substance entry' });
 
     await user.type(within(form).getByLabelText('Drug name'), 'Midazolam');
-    await user.selectOptions(within(form).getByLabelText('Control schedule'), 'IV');
-    await user.selectOptions(within(form).getByLabelText('Unit'), 'ML');
+    await user.click(within(form).getByRole('button', { name: /Control schedule/ }));
+    await user.click(within(screen.getByRole('listbox')).getByText('Schedule IV'));
+    await user.click(within(form).getByRole('button', { name: /Unit/ }));
+    await user.click(within(screen.getByRole('listbox')).getByText('mL'));
     await user.type(within(form).getByLabelText('Strength (optional)'), '5');
     await user.type(within(form).getByLabelText('Lot number (optional)'), 'LOT-9');
     await user.type(within(form).getByLabelText('Amount drawn'), '5');

--- a/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/InsuranceClaims.test.tsx
@@ -248,7 +248,8 @@ describe('InsuranceClaims detail actions', () => {
     const onUpdateStatus = jest.fn();
     setup({ claims: [CLAIMS[1]], activeClaimId: 'c2', onUpdateStatus });
 
-    await userEvent.selectOptions(screen.getByLabelText('Move claim to'), 'APPROVED');
+    await userEvent.click(screen.getByRole('button', { name: /Move claim to/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Approved'));
     await userEvent.click(screen.getByRole('button', { name: "Update this claim's status" }));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
@@ -267,7 +268,8 @@ describe('InsuranceClaims detail actions', () => {
     // c2 was submitted for 199.5; approving for 500 must be caught client-side.
     setup({ claims: [CLAIMS[1]], activeClaimId: 'c2', onUpdateStatus });
 
-    await userEvent.selectOptions(screen.getByLabelText('Move claim to'), 'APPROVED');
+    await userEvent.click(screen.getByRole('button', { name: /Move claim to/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Approved'));
     await userEvent.type(screen.getByLabelText('Approved amount'), '500');
     await userEvent.click(screen.getByRole('button', { name: "Update this claim's status" }));
 
@@ -352,7 +354,8 @@ describe('InsuranceClaims create form', () => {
     const onCreate = jest.fn();
     setup({ createOpen: true, claims: [], onCreate });
 
-    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'pat-1');
+    await userEvent.click(screen.getByRole('button', { name: /Companion/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Marnie Whitlock'));
     await userEvent.clear(screen.getByLabelText('Insurer'));
     await userEvent.type(screen.getByLabelText('Insurer'), 'Petsure');
     await userEvent.type(screen.getByLabelText('Policy number'), 'PS-1');
@@ -374,7 +377,8 @@ describe('InsuranceClaims create form', () => {
     const onCreate = jest.fn();
     setup({ createOpen: true, claims: [], onCreate });
 
-    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'pat-1');
+    await userEvent.click(screen.getByRole('button', { name: /Companion/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Marnie Whitlock'));
     await userEvent.type(screen.getByLabelText('Insurer'), 'Petsure');
     await userEvent.type(screen.getByLabelText('Policy number'), 'PS-1');
     await userEvent.type(screen.getByLabelText(/Submitted amount/), '0');

--- a/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/finance/Sections/CreateEstimateDialog.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -156,6 +156,11 @@ const summaryValue = (label: string) => screen.getByText(label).nextElementSibli
 
 const createButton = () => screen.getByRole('button', { name: 'Create this estimate' });
 
+const selectCompanion = async (name: string) => {
+  await userEvent.click(screen.getByRole('button', { name: 'Companion' }));
+  await userEvent.click(within(screen.getByRole('listbox')).getByText(name));
+};
+
 const fillLine = async (
   index: number,
   values: { description: string; quantity: string; unitPrice: string; taxRate: string }
@@ -176,7 +181,7 @@ describe('CreateEstimateDialog', () => {
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
   });
 
-  it('opens with one empty line and a zeroed summary', () => {
+  it('opens with one empty line and a zeroed summary', async () => {
     setup();
 
     expect(screen.getByRole('dialog', { name: 'Create an estimate' })).toBeInTheDocument();
@@ -187,7 +192,11 @@ describe('CreateEstimateDialog', () => {
     expect(summaryValue('Subtotal')).toBe('$0.00');
     expect(summaryValue('Tax')).toBe('$0.00');
     expect(summaryValue('Total')).toBe('$0.00');
-    expect(screen.getByRole('option', { name: 'Bruno' })).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Companion' }));
+    expect(
+      within(screen.getByRole('listbox')).getByRole('option', { name: 'Bruno' })
+    ).toBeInTheDocument();
   });
 
   it('recomputes the line total and the summary as the line is typed', async () => {
@@ -254,7 +263,7 @@ describe('CreateEstimateDialog', () => {
   it('blocks a submit with an invalid line and clears the message once it is fixed', async () => {
     const { onSubmit } = setup();
 
-    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'c1');
+    await selectCompanion('Bruno');
     await userEvent.click(createButton());
 
     expect(await screen.findByRole('alert')).toHaveTextContent('Every line needs a description.');
@@ -275,7 +284,7 @@ describe('CreateEstimateDialog', () => {
   it('submits the draft as a CreateEstimateInput with numeric items and an ISO validUntil', async () => {
     const { onSubmit } = setup();
 
-    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'c2');
+    await selectCompanion('Mango');
     fireEvent.change(screen.getByLabelText('Valid until (optional)'), {
       target: { value: '2026-12-31' },
     });
@@ -309,7 +318,7 @@ describe('CreateEstimateDialog', () => {
   it('omits the optional fields when they were left empty', async () => {
     const { onSubmit } = setup();
 
-    await userEvent.selectOptions(screen.getByLabelText('Companion'), 'c1');
+    await selectCompanion('Bruno');
     await fillLine(1, {
       description: 'Dental clean',
       quantity: '2',

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/TreatmentStep.test.tsx
@@ -458,8 +458,8 @@ describe('TreatmentStep', () => {
     // Each row shows the line price at the right end and a Refill field.
     expect(screen.getByText('$165')).toBeInTheDocument();
     expect(screen.getAllByLabelText('Refills').length).toBeGreaterThan(0);
-    // Fulfillment is a pill dropdown (not checkboxes), defaulting to the value.
-    expect(screen.getAllByRole('combobox', { name: /fulfillment/i }).length).toBeGreaterThan(0);
+    // Fulfillment is a shared Dropdown (not checkboxes), defaulting to the value.
+    expect(screen.getAllByRole('button', { name: /fulfillment/i }).length).toBeGreaterThan(0);
     expect(screen.getAllByText('In-house fulfilled').length).toBeGreaterThan(0);
     // The old "Medication" tag no longer appears on the cards.
     expect(screen.queryByText('Medication')).not.toBeInTheDocument();
@@ -489,7 +489,7 @@ describe('TreatmentStep', () => {
 
     // The locked state is surfaced, and the row's controls are read-only.
     expect(screen.getByText('Finalized')).toBeInTheDocument();
-    expect(screen.getByRole('combobox', { name: /fulfillment/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /fulfillment/i })).toBeDisabled();
   });
 
   it('does not block Save Treatment on a finalized row missing a now-required field', async () => {
@@ -661,10 +661,9 @@ describe('TreatmentStep', () => {
     );
     expect(savePrescriptionArtifact).not.toHaveBeenCalled();
 
-    // Fulfillment is a compact pill dropdown: open it, then pick the option.
-    fireEvent.change(screen.getAllByRole('combobox', { name: /fulfillment/i })[0], {
-      target: { value: 'PRESCRIPTION_ONLY' },
-    });
+    // Fulfillment is a shared Dropdown: open it, then pick the option.
+    fireEvent.click(screen.getAllByRole('button', { name: /fulfillment/i })[0]);
+    fireEvent.click(screen.getByRole('option', { name: 'Prescription only' }));
     expect(
       useAppointmentWorkspaceStore.getState().getEncounter(APPT)?.prescription[0].fulfillment
     ).toBe('PRESCRIPTION_ONLY');

--- a/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/ContactusPage.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import ContactusPage from '@/app/features/marketing/pages/ContactusPage/ContactusPage';
@@ -337,9 +337,12 @@ describe('ContactusPage', () => {
           'Submit data service access request as The person whose name appears above'
         )
       );
-      fireEvent.change(screen.getByTestId('dynamic-select'), {
-        target: { value: 'UK_GDPR' },
-      });
+      await userEvent.click(
+        screen.getByRole('button', { name: /Under the rights of which law are you making/ })
+      );
+      await userEvent.click(
+        within(screen.getByRole('listbox')).getByText('UK GDPR / Data Protection Act 2018')
+      );
       fireEvent.click(
         screen.getByLabelText(
           'Submit data service access request to Access your personal information'

--- a/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Finance/Estimates.test.tsx
@@ -375,10 +375,14 @@ describe('Finance > Estimates page', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Create a new estimate' }));
 
     const dialog = screen.getByRole('dialog', { name: 'Create an estimate' });
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Companion' }));
+    const companionListbox = screen.getByRole('listbox');
     // A companion with no stored name is still selectable, under a placeholder.
-    expect(within(dialog).getByRole('option', { name: 'Unnamed companion' })).toBeInTheDocument();
+    expect(
+      within(companionListbox).getByRole('option', { name: 'Unnamed companion' })
+    ).toBeInTheDocument();
+    await userEvent.click(within(companionListbox).getByText('Unnamed companion'));
 
-    await userEvent.selectOptions(within(dialog).getByLabelText('Companion'), 'c2');
     await userEvent.type(within(dialog).getByLabelText('Line 1 description'), 'Dental clean');
     await userEvent.clear(within(dialog).getByLabelText('Line 1 unit price'));
     await userEvent.type(within(dialog).getByLabelText('Line 1 unit price'), '50');
@@ -412,7 +416,8 @@ describe('Finance > Estimates page', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Create a new estimate' }));
     const dialog = screen.getByRole('dialog', { name: 'Create an estimate' });
-    await userEvent.selectOptions(within(dialog).getByLabelText('Companion'), 'c1');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Companion' }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Bruno'));
     await userEvent.type(within(dialog).getByLabelText('Line 1 description'), 'Dental clean');
     await userEvent.type(within(dialog).getByLabelText('Line 1 unit price'), '50');
     await userEvent.click(within(dialog).getByRole('button', { name: 'Create this estimate' }));
@@ -658,7 +663,8 @@ describe('Finance > Estimates status filters', () => {
 
     await userEvent.click(screen.getByRole('button', { name: 'Create a new estimate' }));
     const dialog = screen.getByRole('dialog', { name: 'Create an estimate' });
-    await userEvent.selectOptions(within(dialog).getByLabelText('Companion'), 'c1');
+    await userEvent.click(within(dialog).getByRole('button', { name: 'Companion' }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Bruno'));
     await userEvent.type(within(dialog).getByLabelText('Line 1 description'), 'Dental clean');
     await userEvent.clear(within(dialog).getByLabelText('Line 1 unit price'));
     await userEvent.type(within(dialog).getByLabelText('Line 1 unit price'), '50');

--- a/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/PublicBookingSetup.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
 const notifyMock = jest.fn();
@@ -62,6 +63,8 @@ jest.mock('react-icons/io5', () => ({
   IoCopyOutline: () => <span data-testid="i-copy" />,
   IoGlobeOutline: () => <span data-testid="i-globe" />,
   IoSaveOutline: () => <span data-testid="i-save" />,
+  // Dropdown (converted native selects) renders its own chevron icon.
+  IoChevronDown: () => <span data-testid="i-chevron" />,
 }));
 
 import PublicBookingSetup from '@/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup';
@@ -135,17 +138,20 @@ describe('PublicBookingSetup', () => {
   it('shows keyboard focus on every notched field', async () => {
     /* globals.css suppresses the outline on input/select/textarea on the grounds
        that "each field shows border-color on focus", and the inner controls here
-       add their own outline-none. These five wrappers had neither, so tabbing
-       through this page gave a keyboard user no indication of where they were.
-       The affordance lives on the wrapper, so that is what this checks. */
-    await renderSetup();
+       add their own outline-none. These wrappers had neither, so tabbing through
+       this page gave a keyboard user no indication of where they were. The
+       affordance lives on the wrapper, so that is what this checks. Bookable
+       window and Buffer between visits now use the shared Dropdown component,
+       which manages its own focus affordance, so only the branding step's
+       notched fields remain to check here. */
+    await goToBranding();
 
     // The notched-field recipe exactly: a hairline 14px box. Other 14px-radius
     // elements on this page are buttons and are not focus surfaces.
     const notched = document.querySelectorAll('[class*="border-[var(--hairline)] rounded-[14px]"]');
-    // Two on this step; the other three are on later wizard steps. The count
+    // Three on this step: logo, welcome message, reply-to email. The count
     // only proves the query found the recipe - the per-field loop is the guard.
-    expect(notched.length).toBeGreaterThanOrEqual(2);
+    expect(notched.length).toBeGreaterThanOrEqual(3);
     for (const field of notched) {
       expect(field.className).toContain('focus-within:border-[var(--color-input-border-active)]');
     }
@@ -252,13 +258,17 @@ describe('PublicBookingSetup', () => {
   it('updates availability selects while confirmation remains fixed', async () => {
     await renderSetup();
 
-    const windowSelect = screen.getByLabelText('Bookable window') as HTMLSelectElement;
-    fireEvent.change(windowSelect, { target: { value: '56' } });
-    expect(windowSelect.value).toBe('56');
+    await userEvent.click(screen.getByRole('button', { name: /Bookable window/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('Up to 8 weeks ahead'));
+    expect(screen.getByRole('button', { name: /Bookable window/ })).toHaveTextContent(
+      'Up to 8 weeks ahead'
+    );
 
-    const bufferSelect = screen.getByLabelText('Buffer between visits') as HTMLSelectElement;
-    fireEvent.change(bufferSelect, { target: { value: '30' } });
-    expect(bufferSelect.value).toBe('30');
+    await userEvent.click(screen.getByRole('button', { name: /Buffer between visits/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('30 minutes'));
+    expect(screen.getByRole('button', { name: /Buffer between visits/ })).toHaveTextContent(
+      '30 minutes'
+    );
 
     expect(screen.getByText('Requests need confirmation.')).toBeInTheDocument();
     expect(
@@ -467,10 +477,12 @@ describe('PublicBookingSetup', () => {
       await renderSetup();
 
       await waitFor(() =>
-        expect((screen.getByLabelText('Bookable window') as HTMLSelectElement).value).toBe('56')
+        expect(screen.getByRole('button', { name: /Bookable window/ })).toHaveTextContent(
+          'Up to 8 weeks ahead'
+        )
       );
-      expect((screen.getByLabelText('Buffer between visits') as HTMLSelectElement).value).toBe(
-        '30'
+      expect(screen.getByRole('button', { name: /Buffer between visits/ })).toHaveTextContent(
+        '30 minutes'
       );
       fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
       expect((screen.getByLabelText('Welcome message') as HTMLInputElement).value).toBe(
@@ -602,8 +614,10 @@ describe('PublicBookingSetup', () => {
       await waitFor(() => expect(getConfigMock).toHaveBeenCalled());
 
       fireEvent.click(screen.getByRole('button', { name: /Wellness & vaccination/ }));
-      fireEvent.change(screen.getByLabelText('Bookable window'), { target: { value: '14' } });
-      fireEvent.change(screen.getByLabelText('Buffer between visits'), { target: { value: '0' } });
+      await userEvent.click(screen.getByRole('button', { name: /Bookable window/ }));
+      await userEvent.click(within(screen.getByRole('listbox')).getByText('Up to 2 weeks ahead'));
+      await userEvent.click(screen.getByRole('button', { name: /Buffer between visits/ }));
+      await userEvent.click(within(screen.getByRole('listbox')).getByText('0 minutes'));
       fireEvent.click(screen.getByRole('button', { name: /Continue/ }));
       fireEvent.change(screen.getByLabelText('Welcome message'), {
         target: { value: '  Come and see us  ' },

--- a/apps/frontend/src/app/__tests__/pages/SignUp.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/SignUp.test.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
@@ -159,9 +160,8 @@ describe('SignUp page', () => {
     authStoreMock.signUp.mockResolvedValue(true);
     render(<SignUp />);
 
-    fireEvent.change(screen.getByLabelText('I am'), {
-      target: { value: 'A developer' },
-    });
+    await userEvent.click(screen.getByRole('button', { name: /I am/ }));
+    await userEvent.click(within(screen.getByRole('listbox')).getByText('A developer'));
     fillValidForm();
     fireEvent.click(getSubmitBtn());
 

--- a/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
+++ b/apps/frontend/src/app/features/appointments/components/FrontDeskBoard/FrontDeskBoard.tsx
@@ -8,6 +8,7 @@ import {
   panelInputClass as inputClass,
 } from '@/app/ui/primitives/PanelStates/PanelStates';
 import { CompanionSelect } from '@/app/features/appointments/components/CompanionSelect';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import { IoPulseOutline, IoAddOutline } from 'react-icons/io5';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { Textarea } from '@/app/ui/Input';
@@ -93,6 +94,11 @@ const TRIAGE_LABEL: Record<TriagePriority, string> = {
   STANDARD: 'Standard',
   NON_URGENT: 'Non-urgent',
 };
+
+const TRIAGE_DROPDOWN_OPTIONS = TRIAGE_ORDER.map((priority) => ({
+  label: TRIAGE_LABEL[priority],
+  value: priority,
+}));
 
 const STATUS_TONE: Record<CheckInStatus, StatusTone> = {
   WAITING: 'info',
@@ -230,28 +236,15 @@ const RoomControl = ({
   rooms: CheckInRoomOption[];
   busy: boolean;
   onAssignRoom: (id: string, roomId: string) => void;
-}) => {
-  const selectId = `checkin-room-${entry.id}`;
-  return (
-    <label className="flex items-center gap-1.5" htmlFor={selectId}>
-      <span className="sr-only">Assign room</span>
-      <select
-        id={selectId}
-        className={clsx(inputClass, 'w-auto py-1')}
-        value={entry.assignedRoomId ?? ''}
-        disabled={busy}
-        onChange={(e) => e.target.value && onAssignRoom(entry.id, e.target.value)}
-      >
-        <option value="">Assign room</option>
-        {rooms.map((room) => (
-          <option key={room.id} value={room.id}>
-            {room.name}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-};
+}) => (
+  <Dropdown
+    placeholder="Assign room"
+    value={entry.assignedRoomId ?? ''}
+    onChange={(roomId) => onAssignRoom(entry.id, roomId)}
+    options={rooms.map((room) => ({ label: room.name, value: room.id }))}
+    disabled={busy}
+  />
+);
 
 const CheckInRow = ({
   entry,
@@ -372,21 +365,12 @@ type AddCheckInFormState = ReturnType<typeof useAddCheckInForm>;
 
 const CheckInTimingFields = ({ form }: { form: AddCheckInFormState }) => (
   <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-    <label className="flex flex-col gap-1" htmlFor="checkin-triage">
-      <span className={fieldLabelClass}>Triage priority</span>
-      <select
-        id="checkin-triage"
-        className={inputClass}
-        value={form.triagePriority}
-        onChange={(e) => form.setTriagePriority(e.target.value as TriagePriority)}
-      >
-        {TRIAGE_ORDER.map((priority) => (
-          <option key={priority} value={priority}>
-            {TRIAGE_LABEL[priority]}
-          </option>
-        ))}
-      </select>
-    </label>
+    <Dropdown
+      placeholder="Triage priority"
+      value={form.triagePriority}
+      onChange={(v) => form.setTriagePriority(v as TriagePriority)}
+      options={TRIAGE_DROPDOWN_OPTIONS}
+    />
     <label className="flex flex-col gap-1" htmlFor="checkin-arrived">
       <span className={fieldLabelClass}>Arrived at</span>
       <input

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PrescriptionEditor.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import {
-  IoChevronDownOutline,
   IoCopyOutline,
   IoLockClosedOutline,
   IoPrintOutline,
@@ -16,6 +15,7 @@ import {
   type MedicationSuggestion,
 } from '@/app/features/appointments/services/clinicalTermsService';
 import FormInput from '@/app/ui/inputs/FormInput/FormInput';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
 import type { DropdownOption } from '@/app/hooks/useDropdown';
 import CircleIconButton from '@/app/features/appointments/pages/AppointmentWorkspace/components/CircleIconButton';
@@ -63,6 +63,10 @@ const FULFILLMENT_LABELS: Record<PrescriptionFulfillment, string> = {
 };
 
 const FULFILLMENT_OPTIONS = Object.keys(FULFILLMENT_LABELS) as PrescriptionFulfillment[];
+const FULFILLMENT_DROPDOWN_OPTIONS = FULFILLMENT_OPTIONS.map((option) => ({
+  label: FULFILLMENT_LABELS[option],
+  value: option,
+}));
 const EMPTY_CATALOG_ITEMS: Omit<PrescriptionItem, 'id'>[] = [];
 const EMPTY_TEMPLATE_ITEMS: PrescriptionTemplateOption[] = [];
 
@@ -99,8 +103,9 @@ const isClassificationOnly = (item: PrescriptionItem) =>
   Boolean(item.atcCode) && !item.inventoryItemId && !item.sku;
 
 /**
- * Compact fulfillment pill dropdown (In-house fulfilled / Prescription only),
- * styled like the workspace status pills with a small caret.
+ * Fulfillment dropdown (In-house fulfilled / Prescription only), using the
+ * shared design-system Dropdown so it matches the rest of the app instead of
+ * a browser-native <select>.
  */
 const FulfillmentDropdown = ({
   value,
@@ -110,34 +115,15 @@ const FulfillmentDropdown = ({
   value: PrescriptionFulfillment;
   disabled: boolean;
   onChange: (value: PrescriptionFulfillment) => void;
-}) => {
-  const [open, setOpen] = useState(false);
-
-  return (
-    <div className="relative">
-      <select
-        aria-label="Fulfillment"
-        disabled={disabled}
-        value={value}
-        onChange={(e) => onChange(e.target.value as PrescriptionFulfillment)}
-        onFocus={() => setOpen(true)}
-        onBlur={() => setOpen(false)}
-        className="flex appearance-none items-center gap-1 rounded-[13px] border border-[var(--hairline)] bg-[var(--field-bg)] py-1.5 pr-10 pl-4 text-[14px] leading-[120%] font-medium text-[var(--ink-body)] disabled:cursor-not-allowed disabled:opacity-60"
-      >
-        {FULFILLMENT_OPTIONS.map((option) => (
-          <option key={option} value={option}>
-            {FULFILLMENT_LABELS[option]}
-          </option>
-        ))}
-      </select>
-      <IoChevronDownOutline
-        size={16}
-        aria-hidden="true"
-        className={`pointer-events-none absolute top-1/2 right-3 -translate-y-1/2 transition-transform ${open ? 'rotate-180' : ''}`}
-      />
-    </div>
-  );
-};
+}) => (
+  <Dropdown
+    placeholder="Fulfillment"
+    value={value}
+    disabled={disabled}
+    onChange={(v) => onChange(v as PrescriptionFulfillment)}
+    options={FULFILLMENT_DROPDOWN_OPTIONS}
+  />
+);
 
 /** Small neutral pill that surfaces an inventory-owned fact (read-only). */
 const FactChip = ({ label, value }: { label: string; value?: string }) => {

--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx
@@ -21,6 +21,7 @@ import { setStorageItem } from '@/app/lib/browserStorage';
 import { resetSidebarPreference } from '@/app/lib/sidebarPreference';
 import { AuthShell, AuthBrandContent } from '@/app/features/marketing/site';
 import { GithubSignInButton } from '@/app/features/auth/pages/GithubSignInButton';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import {
   AuthForm,
   AuthHeading,
@@ -34,6 +35,8 @@ import {
 
 const CLINIC_ROLE = 'A veterinary clinic, practice, or hospital';
 const DEVELOPER_ROLE = 'A developer';
+
+const ROLE_DROPDOWN_OPTIONS = [CLINIC_ROLE, DEVELOPER_ROLE];
 
 const CLINIC_POINTS = [
   {
@@ -227,21 +230,12 @@ type SignUpRoleFieldProps = {
 };
 
 const SignUpRoleField = ({ role, onRoleChange }: SignUpRoleFieldProps) => (
-  <div style={{ display: 'flex', flexDirection: 'column', gap: 7 }}>
-    <label className="yc-lbl" htmlFor="signup-role">
-      I am
-    </label>
-    <select
-      id="signup-role"
-      className="yc-field"
-      aria-label="I am"
-      value={role}
-      onChange={(e) => onRoleChange(e.target.value)}
-    >
-      <option value={CLINIC_ROLE}>{CLINIC_ROLE}</option>
-      <option value={DEVELOPER_ROLE}>{DEVELOPER_ROLE}</option>
-    </select>
-  </div>
+  <Dropdown
+    placeholder="I am"
+    value={role}
+    onChange={onRoleChange}
+    options={ROLE_DROPDOWN_OPTIONS}
+  />
 );
 
 type SignUpFieldsProps = {

--- a/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/AllergyList.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/app/features/companionHistory/components/ClinicalListChrome';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import type {
   AllergySeverity,
   AllergyStatus,
@@ -88,6 +89,12 @@ const TYPE_LABEL: Record<AllergyType, string> = {
 
 const SEVERITY_OPTIONS: AllergySeverity[] = ['MILD', 'MODERATE', 'SEVERE', 'LIFE_THREATENING'];
 const TYPE_OPTIONS: AllergyType[] = ['DRUG', 'FOOD', 'ENVIRONMENTAL', 'OTHER'];
+
+const TYPE_DROPDOWN_OPTIONS = TYPE_OPTIONS.map((t) => ({ label: TYPE_LABEL[t], value: t }));
+const SEVERITY_DROPDOWN_OPTIONS = SEVERITY_OPTIONS.map((s) => ({
+  label: SEVERITY_LABEL[s],
+  value: s,
+}));
 
 const AllergyRow = ({
   allergy,
@@ -205,42 +212,20 @@ const CreateAllergyForm = ({
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
         <div className="flex flex-col gap-1">
-          <label className={fieldLabelClass} htmlFor="allergy-type">
-            Type
-          </label>
-          <select
-            id="allergy-type"
-            className={controlClass}
+          <Dropdown
+            placeholder="Type"
             value={values.allergyType}
-            onChange={(e) =>
-              setValues((v) => ({ ...v, allergyType: e.target.value as AllergyType }))
-            }
-          >
-            {TYPE_OPTIONS.map((t) => (
-              <option key={t} value={t}>
-                {TYPE_LABEL[t]}
-              </option>
-            ))}
-          </select>
+            onChange={(v) => setValues((prev) => ({ ...prev, allergyType: v as AllergyType }))}
+            options={TYPE_DROPDOWN_OPTIONS}
+          />
         </div>
         <div className="flex flex-col gap-1">
-          <label className={fieldLabelClass} htmlFor="allergy-severity">
-            Severity
-          </label>
-          <select
-            id="allergy-severity"
-            className={controlClass}
+          <Dropdown
+            placeholder="Severity"
             value={values.severity}
-            onChange={(e) =>
-              setValues((v) => ({ ...v, severity: e.target.value as AllergySeverity }))
-            }
-          >
-            {SEVERITY_OPTIONS.map((s) => (
-              <option key={s} value={s}>
-                {SEVERITY_LABEL[s]}
-              </option>
-            ))}
-          </select>
+            onChange={(v) => setValues((prev) => ({ ...prev, severity: v as AllergySeverity }))}
+            options={SEVERITY_DROPDOWN_OPTIONS}
+          />
         </div>
       </div>
       <div className="flex flex-col gap-1">

--- a/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/ConsentList.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/app/features/companionHistory/components/ClinicalListChrome';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import type {
   ConsentStatus,
   ConsentType,
@@ -84,6 +85,8 @@ const TYPE_OPTIONS: ConsentType[] = [
   'DNR',
   'OTHER',
 ];
+
+const TYPE_DROPDOWN_OPTIONS = TYPE_OPTIONS.map((t) => ({ label: TYPE_LABEL[t], value: t }));
 
 /**
  * The status pill tone. An active DNR directive reads in the danger tone and an
@@ -277,23 +280,12 @@ const GrantConsentForm = ({
       className="flex flex-col gap-3 border-b border-[var(--divider)] bg-[var(--inset)] px-4 py-4"
       onSubmit={handleSubmit}
     >
-      <div className="flex flex-col gap-1">
-        <label className={fieldLabelClass} htmlFor="consent-type">
-          Consent type
-        </label>
-        <select
-          id="consent-type"
-          className={controlClass}
-          value={values.consentType}
-          onChange={(e) => setValues((v) => ({ ...v, consentType: e.target.value as ConsentType }))}
-        >
-          {TYPE_OPTIONS.map((t) => (
-            <option key={t} value={t}>
-              {TYPE_LABEL[t]}
-            </option>
-          ))}
-        </select>
-      </div>
+      <Dropdown
+        placeholder="Consent type"
+        value={values.consentType}
+        onChange={(v) => setValues((prev) => ({ ...prev, consentType: v as ConsentType }))}
+        options={TYPE_DROPDOWN_OPTIONS}
+      />
       <div className="flex flex-col gap-1">
         <label className={fieldLabelClass} htmlFor="consent-procedure">
           Procedure

--- a/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
+++ b/apps/frontend/src/app/features/companionHistory/components/FlagList.tsx
@@ -6,6 +6,7 @@ import { IoAddOutline, IoCheckmarkOutline, IoFlagOutline } from 'react-icons/io5
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import type {
   FlagSeverity,
   PatientFlag,
@@ -68,6 +69,15 @@ const TYPE_OPTIONS: PatientFlagType[] = [
   'OTHER',
 ];
 const SEVERITY_OPTIONS: FlagSeverity[] = ['LOW', 'MEDIUM', 'HIGH', 'CRITICAL'];
+
+const FLAG_TYPE_DROPDOWN_OPTIONS = TYPE_OPTIONS.map((type) => ({
+  label: TYPE_LABEL[type],
+  value: type,
+}));
+const SEVERITY_DROPDOWN_OPTIONS = SEVERITY_OPTIONS.map((severity) => ({
+  label: SEVERITY_LABEL[severity],
+  value: severity,
+}));
 
 const cardClass =
   'flex w-full flex-col rounded-2xl border border-[var(--hairline)] bg-[var(--screen)] shadow-[0_1px_2px_var(--sh03)]';
@@ -192,50 +202,22 @@ const CreateFlagForm = ({ creating, onCreate, onCancel }: CreateFlagFormProps) =
         />
       </div>
       <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-        <div className="flex flex-col gap-1">
-          <label className={fieldLabelClass} htmlFor="patient-flag-type">
-            Flag type
-          </label>
-          <select
-            id="patient-flag-type"
-            className={controlClass}
-            value={values.flagType}
-            onChange={(event) =>
-              setValues((current) => ({
-                ...current,
-                flagType: event.target.value as PatientFlagType,
-              }))
-            }
-          >
-            {TYPE_OPTIONS.map((type) => (
-              <option key={type} value={type}>
-                {TYPE_LABEL[type]}
-              </option>
-            ))}
-          </select>
-        </div>
-        <div className="flex flex-col gap-1">
-          <label className={fieldLabelClass} htmlFor="patient-flag-severity">
-            Severity
-          </label>
-          <select
-            id="patient-flag-severity"
-            className={controlClass}
-            value={values.severity}
-            onChange={(event) =>
-              setValues((current) => ({
-                ...current,
-                severity: event.target.value as FlagSeverity,
-              }))
-            }
-          >
-            {SEVERITY_OPTIONS.map((severity) => (
-              <option key={severity} value={severity}>
-                {SEVERITY_LABEL[severity]}
-              </option>
-            ))}
-          </select>
-        </div>
+        <Dropdown
+          placeholder="Flag type"
+          value={values.flagType}
+          onChange={(value) =>
+            setValues((current) => ({ ...current, flagType: value as PatientFlagType }))
+          }
+          options={FLAG_TYPE_DROPDOWN_OPTIONS}
+        />
+        <Dropdown
+          placeholder="Severity"
+          value={values.severity}
+          onChange={(value) =>
+            setValues((current) => ({ ...current, severity: value as FlagSeverity }))
+          }
+          options={SEVERITY_DROPDOWN_OPTIONS}
+        />
       </div>
       <div className="flex flex-col gap-1">
         <label className={fieldLabelClass} htmlFor="patient-flag-description">

--- a/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
+++ b/apps/frontend/src/app/features/compliance/components/ControlledSubstanceRegister.tsx
@@ -8,6 +8,7 @@ import StatusPill from '@/app/ui/primitives/StatusPill/StatusPill';
 import GenericTable, { type Column } from '@/app/ui/tables/GenericTable/GenericTable';
 import PaginatedCardList from '@/app/ui/tables/PaginatedCardList';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import { formatDateTimeLocal } from '@/app/lib/date';
 import {
   DEA_SCHEDULES,
@@ -44,6 +45,16 @@ const inputClass =
   'min-w-0 flex-1 bg-transparent px-3 py-2 text-body-4 text-text-primary outline-none';
 const labelClass = 'text-caption-2 font-bold text-text-tertiary';
 const PHONE_REGISTER_PAGE_SIZE = 10;
+
+const DEA_SCHEDULE_DROPDOWN_OPTIONS = DEA_SCHEDULES.map((schedule) => ({
+  label: DEA_SCHEDULE_LABEL[schedule],
+  value: schedule,
+}));
+
+const DRUG_UNIT_DROPDOWN_OPTIONS = DRUG_UNITS.map((unit) => ({
+  label: DRUG_UNIT_LABEL[unit],
+  value: unit,
+}));
 
 /** yyyy-mm-dd (from a date input) to the ISO datetime the API's date bounds want. */
 const toIsoBound = (date: string, endOfDay: boolean): string | undefined => {
@@ -553,35 +564,19 @@ const AddEntryForm = ({ creating, createError, onSubmit, onCancel }: AddEntryFor
           />
         </Field>
 
-        <Field id="cs-schedule" label="Control schedule">
-          <select
-            id="cs-schedule"
-            value={deaSchedule}
-            onChange={(event) => setDeaSchedule(event.target.value as DeaSchedule)}
-            className={inputClass}
-          >
-            {DEA_SCHEDULES.map((schedule) => (
-              <option key={schedule} value={schedule}>
-                {DEA_SCHEDULE_LABEL[schedule]}
-              </option>
-            ))}
-          </select>
-        </Field>
+        <Dropdown
+          placeholder="Control schedule"
+          value={deaSchedule}
+          onChange={(v) => setDeaSchedule(v as DeaSchedule)}
+          options={DEA_SCHEDULE_DROPDOWN_OPTIONS}
+        />
 
-        <Field id="cs-unit" label="Unit">
-          <select
-            id="cs-unit"
-            value={unit}
-            onChange={(event) => setUnit(event.target.value as DrugUnit)}
-            className={inputClass}
-          >
-            {DRUG_UNITS.map((option) => (
-              <option key={option} value={option}>
-                {DRUG_UNIT_LABEL[option]}
-              </option>
-            ))}
-          </select>
-        </Field>
+        <Dropdown
+          placeholder="Unit"
+          value={unit}
+          onChange={(v) => setUnit(v as DrugUnit)}
+          options={DRUG_UNIT_DROPDOWN_OPTIONS}
+        />
 
         <Field id="cs-strength" label="Strength (optional)">
           <input

--- a/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/CreateKeyForm.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperApiKeys/CreateKeyForm.tsx
@@ -2,6 +2,7 @@
 import React, { useState } from 'react';
 
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import type { ApiKeyEnvironment } from '@/app/services/developerApiKeys';
 
 export interface NewApiKeyInput {
@@ -9,6 +10,11 @@ export interface NewApiKeyInput {
   environment: ApiKeyEnvironment;
   scopes?: string[];
 }
+
+const ENVIRONMENT_DROPDOWN_OPTIONS = [
+  { label: 'Live', value: 'live' },
+  { label: 'Test', value: 'test' },
+];
 
 /**
  * Owns its own field state.
@@ -61,18 +67,12 @@ const CreateKeyForm = ({
         placeholder="e.g. Production server"
         maxLength={100}
       />
-      <label className="text-body-3 text-text-primary" htmlFor="apiKeyEnv">
-        Environment
-      </label>
-      <select
-        id="apiKeyEnv"
-        className="DevApiKeys-input"
+      <Dropdown
+        placeholder="Environment"
         value={environment}
-        onChange={(event) => setEnvironment(event.target.value as ApiKeyEnvironment)}
-      >
-        <option value="live">Live</option>
-        <option value="test">Test</option>
-      </select>
+        onChange={(value) => setEnvironment(value as ApiKeyEnvironment)}
+        options={ENVIRONMENT_DROPDOWN_OPTIONS}
+      />
       <label className="text-body-3 text-text-primary" htmlFor="apiKeyScopes">
         Scopes (optional, comma-separated)
       </label>

--- a/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Estimates/Sections/EstimateDraftFields.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { Secondary } from '@/app/ui/primitives/Buttons';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import { formatMoneyPrecise } from '@/app/lib/money';
 import EstimateLineRow from '@/app/features/finance/pages/Estimates/Sections/EstimateLineRow';
 import {
@@ -29,26 +30,13 @@ export const EstimateHeaderFields = ({
   setValidUntil: (value: string) => void;
 }) => (
   <>
-    <div className="flex flex-col gap-1">
-      <label htmlFor="estimate-companion" className="text-caption-2 font-bold text-text-tertiary">
-        Companion
-      </label>
-      <span className={fieldClass}>
-        <select
-          id="estimate-companion"
-          value={patientId}
-          onChange={(e) => setPatientId(e.target.value)}
-          className={inputClass}
-        >
-          <option value="">Choose a companion</option>
-          {companions.map((companion) => (
-            <option key={companion.id} value={companion.id}>
-              {companion.name}
-            </option>
-          ))}
-        </select>
-      </span>
-    </div>
+    <Dropdown
+      placeholder="Companion"
+      value={patientId}
+      onChange={setPatientId}
+      options={companions.map((companion) => ({ label: companion.name, value: companion.id }))}
+      emptyLabel="Choose a companion"
+    />
 
     <div className="flex flex-col gap-1">
       <label htmlFor="estimate-valid-until" className="text-caption-2 font-bold text-text-tertiary">

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimDetail.tsx
@@ -6,6 +6,7 @@ import { formatDisplayDate } from '@/app/lib/date';
 import { Primary, Secondary } from '@/app/ui/primitives/Buttons';
 import { PermissionGate } from '@/app/ui/layout/guards/PermissionGate';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import { PERMISSIONS } from '@/app/lib/permissions';
 import {
   fieldClass,
@@ -124,24 +125,13 @@ const StatusChangeForm = ({
 
   return (
     <div className="flex flex-col gap-3 rounded-2xl border border-card-border p-4!">
-      <div className="flex flex-col gap-1">
-        <label htmlFor="claim-next-status" className="text-caption-2 font-bold text-text-tertiary">
-          Move claim to
-        </label>
-        <span className={`${fieldClass} max-w-72`}>
-          <select
-            id="claim-next-status"
-            value={status}
-            onChange={(e) => setStatus(e.target.value as InsuranceClaimStatus)}
-            className={inputClass}
-          >
-            {options.map((option) => (
-              <option key={option} value={option}>
-                {claimStatusLabel(option)}
-              </option>
-            ))}
-          </select>
-        </span>
+      <div className="max-w-72">
+        <Dropdown
+          placeholder="Move claim to"
+          value={status}
+          onChange={(v) => setStatus(v as InsuranceClaimStatus)}
+          options={options.map((option) => ({ label: claimStatusLabel(option), value: option }))}
+        />
       </div>
 
       {statusNeedsApprovedAmount(status) && (

--- a/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.tsx
+++ b/apps/frontend/src/app/features/finance/pages/InsuranceClaims/Sections/InsuranceClaimFormFields.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import { currencySymbol } from '@/app/lib/money';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import {
   fieldClass,
   inputClass,
@@ -31,24 +32,13 @@ const InsuranceClaimFormFields = ({
 }: InsuranceClaimFormFieldsProps) => (
   <>
     <div className="flex flex-col gap-1">
-      <label htmlFor="claim-companion" className="text-caption-2 font-bold text-text-tertiary">
-        Companion
-      </label>
-      <span className={fieldClass}>
-        <select
-          id="claim-companion"
-          value={draft.patientId}
-          onChange={(e) => setField({ patientId: e.target.value })}
-          className={inputClass}
-        >
-          <option value="">Choose a companion</option>
-          {companions.map((companion) => (
-            <option key={companion.id} value={companion.id}>
-              {companion.name}
-            </option>
-          ))}
-        </select>
-      </span>
+      <Dropdown
+        placeholder="Companion"
+        value={draft.patientId}
+        onChange={(v) => setField({ patientId: v })}
+        options={companions.map((companion) => ({ label: companion.name, value: companion.id }))}
+        emptyLabel="Choose a companion"
+      />
     </div>
 
     <div className="flex flex-col gap-1">

--- a/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
+++ b/apps/frontend/src/app/features/marketing/pages/ContactusPage/ContactusPage.tsx
@@ -23,6 +23,7 @@ import {
 import { postData } from '@/app/services/axios';
 import { makeOptions } from '@/app/lib/options';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 
 const NEWSREADER = 'var(--font-newsreader)';
 const EASE = 'cubic-bezier(0.16,1,0.3,1)';
@@ -1020,27 +1021,13 @@ function DsarFields({ values, setters, errors, confirm, submit }: Readonly<DsarF
         onSelect={setters.setSubselectedRequest}
       />
 
-      <div style={groupBlock}>
-        <label className="yc-lbl" htmlFor="dsar-area">
-          Under the rights of which law are you making this request?
-          {requiredMark}
-        </label>
-        <select
-          id="dsar-area"
-          className="yc-field"
-          data-testid="dynamic-select"
-          aria-label="Under the rights of which law are you making this request?"
-          value={values.area}
-          onChange={(e) => setters.setArea(e.target.value)}
-        >
-          <option value="">Select one</option>
-          {areaOptions.map((opt) => (
-            <option key={opt.value} value={opt.value}>
-              {opt.label}
-            </option>
-          ))}
-        </select>
-      </div>
+      <Dropdown
+        placeholder="Under the rights of which law are you making this request?"
+        value={values.area}
+        onChange={setters.setArea}
+        options={areaOptions}
+        emptyLabel="Select one"
+      />
 
       <div style={groupBlock}>
         <div style={groupHeading}>You are submitting this request to</div>

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.stories.tsx
@@ -193,9 +193,13 @@ export const ServicesStep: Story = {
     await expect(canvas.queryByText('Full mouth radiograph')).not.toBeInTheDocument();
     await expect(canvas.queryByText('Retired nail trim')).not.toBeInTheDocument();
 
-    // The selects carry the number the API stores, not the label.
-    await expect(canvas.getByRole('combobox', { name: 'Bookable window' })).toHaveValue('28');
-    await expect(canvas.getByRole('combobox', { name: 'Buffer between visits' })).toHaveValue('10');
+    // The Dropdowns carry the number the API stores as their selected label.
+    await expect(canvas.getByRole('button', { name: /Bookable window/ })).toHaveTextContent(
+      'Up to 4 weeks ahead'
+    );
+    await expect(canvas.getByRole('button', { name: /Buffer between visits/ })).toHaveTextContent(
+      '10 minutes'
+    );
     await expect(canvas.getByText('Requests need confirmation.')).toBeInTheDocument();
     await expect(
       canvas.queryByRole('switch', { name: 'Requests need confirmation' })
@@ -367,7 +371,7 @@ export const ServicesStepEmpty: Story = {
 
     // Everything below the list is untouched by the empty state, and Continue is
     // live: an empty booking page can be carried straight through to step 2.
-    await expect(canvas.getByRole('combobox', { name: 'Bookable window' })).toBeEnabled();
+    await expect(canvas.getByRole('button', { name: /Bookable window/ })).toBeEnabled();
     await expect(canvas.getByRole('button', { name: 'Continue' })).toBeEnabled();
   },
   parameters: {

--- a/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import Image from 'next/image';
 import Switch from '@/app/ui/primitives/Switch/Switch';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import {
   IoArrowBack,
   IoArrowForward,
@@ -37,6 +38,16 @@ const BUFFER_OPTIONS: { label: string; minutes: number }[] = [
   { label: '15 minutes', minutes: 15 },
   { label: '30 minutes', minutes: 30 },
 ];
+// Dropdown works in raw strings, so the day/minute counts above are mirrored
+// into string-valued options here rather than parsed back out of a label.
+const WINDOW_DROPDOWN_OPTIONS = WINDOW_OPTIONS.map((opt) => ({
+  label: opt.label,
+  value: String(opt.days),
+}));
+const BUFFER_DROPDOWN_OPTIONS = BUFFER_OPTIONS.map((opt) => ({
+  label: opt.label,
+  value: String(opt.minutes),
+}));
 const copyText = async (value: string): Promise<boolean> => {
   try {
     const clip = globalThis.navigator?.clipboard;
@@ -151,46 +162,18 @@ const BookingServicesStep = ({
       )}
 
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-        {/* focus-within on the WRAPPER, because nothing else can show focus
-            here: globals.css suppresses the outline on input, select and
-            textarea on the grounds that each field shows border-color on focus,
-            and the inner control adds its own outline-none. These five notched
-            fields had neither, so a keyboard user tabbing through the public
-            booking setup got no indication of where they were at all. */}
-        <label className="relative flex items-center h-12 px-3.5 border-[1.5px] border-[var(--hairline)] rounded-[14px] focus-within:border-[var(--color-input-border-active)]">
-          <span className="absolute -top-[7px] left-3 px-1.5 bg-[var(--screen)] text-[10.5px] font-semibold text-[var(--ink-faint)]">
-            Bookable window
-          </span>
-          <select
-            aria-label="Bookable window"
-            value={bookingWindowDays}
-            onChange={(e) => onBookingWindowChange(Number(e.target.value))}
-            className="flex-1 bg-transparent text-[13.5px] font-semibold text-[var(--ink-body)] outline-none"
-          >
-            {WINDOW_OPTIONS.map((opt) => (
-              <option key={opt.days} value={opt.days}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
-        <label className="relative flex items-center h-12 px-3.5 border-[1.5px] border-[var(--hairline)] rounded-[14px] focus-within:border-[var(--color-input-border-active)]">
-          <span className="absolute -top-[7px] left-3 px-1.5 bg-[var(--screen)] text-[10.5px] font-semibold text-[var(--ink-faint)]">
-            Buffer between visits
-          </span>
-          <select
-            aria-label="Buffer between visits"
-            value={bufferMinutes}
-            onChange={(e) => onBufferChange(Number(e.target.value))}
-            className="flex-1 bg-transparent text-[13.5px] font-semibold text-[var(--ink-body)] outline-none"
-          >
-            {BUFFER_OPTIONS.map((opt) => (
-              <option key={opt.minutes} value={opt.minutes}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-        </label>
+        <Dropdown
+          placeholder="Bookable window"
+          value={String(bookingWindowDays)}
+          onChange={(v) => onBookingWindowChange(Number(v))}
+          options={WINDOW_DROPDOWN_OPTIONS}
+        />
+        <Dropdown
+          placeholder="Buffer between visits"
+          value={String(bufferMinutes)}
+          onChange={(v) => onBufferChange(Number(v))}
+          options={BUFFER_DROPDOWN_OPTIONS}
+        />
       </div>
 
       <div className="px-3.5 py-3 rounded-[14px] border border-[var(--divider)] bg-[var(--inset)]">

--- a/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
+++ b/apps/frontend/src/app/features/settings/pages/Settings/Sections/FederationSection.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { useNotify } from '@/app/hooks/useNotify';
 import { Primary } from '@/app/ui/primitives/Buttons';
 import { Textarea } from '@/app/ui/Input';
+import Dropdown from '@/app/ui/inputs/Dropdown/Dropdown';
 import { useConfirm } from '@/app/ui/overlays/Modal/ConfirmModal';
 import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
 import SectionCard from '@/app/ui/primitives/SectionCard/SectionCard';
@@ -43,6 +44,12 @@ const URGENCY_COLORS: Record<APReferralUrgency, string> = {
   URGENT: 'text-warning-700',
   EMERGENCY: 'text-danger-600',
 };
+
+const URGENCY_DROPDOWN_OPTIONS = [
+  { label: URGENCY_LABELS.ROUTINE, value: 'ROUTINE' },
+  { label: URGENCY_LABELS.URGENT, value: 'URGENT' },
+  { label: URGENCY_LABELS.EMERGENCY, value: 'EMERGENCY' },
+];
 
 // Federation states map onto the app's shared pill tones rather than carrying
 // their own colours. The original panel hardcoded Tailwind's default palette,
@@ -642,19 +649,12 @@ const ReferralFormFields = ({
       onChange={(v) => updateSummary('age', v)}
     />
     <div>
-      <label htmlFor="referral-urgency" className={FIELD_LABEL_CLS}>
-        Urgency
-      </label>
-      <select
-        id="referral-urgency"
-        className={REFERRAL_INPUT_CLS}
-        value={form.urgency}
-        onChange={(e) => update('urgency', e.target.value as APReferralUrgency)}
-      >
-        <option value="ROUTINE">Routine</option>
-        <option value="URGENT">Urgent</option>
-        <option value="EMERGENCY">Emergency</option>
-      </select>
+      <Dropdown
+        placeholder="Urgency"
+        value={form.urgency ?? 'ROUTINE'}
+        onChange={(v) => update('urgency', v as APReferralUrgency)}
+        options={URGENCY_DROPDOWN_OPTIONS}
+      />
     </div>
     <ReferralField
       id="referral-chief-complaint"


### PR DESCRIPTION
## Summary
19 fields across 14 files still rendered as a native browser `<select>` (unstyled option list, native OS chrome) instead of the design-system `Dropdown` component used everywhere else in the app. Reported via the Patient History → Consents panel's "Consent type" field; a full codebase sweep found 18 more across companion history, appointments, finance, compliance, onboarding, settings, auth, developer tools and marketing.

| Feature | Files | Fields |
|---|---|---|
| companionHistory | ConsentList, FlagList, AllergyList | Consent type, Flag type, Severity ×2, Allergy type |
| appointments | FrontDeskBoard, PrescriptionEditor | Assign room, Triage priority, Fulfillment |
| finance | EstimateDraftFields, InsuranceClaimFormFields, InsuranceClaimDetail | Companion ×2, Move claim to |
| compliance | ControlledSubstanceRegister | Control schedule, Unit |
| onboarding | PublicBookingSetup | Bookable window, Buffer between visits |
| settings, auth, developers, marketing | FederationSection, SignUp, CreateKeyForm, ContactusPage | Referral urgency, "I am", Environment, DSAR law |

Same mechanical fix throughout: swap the native `<select>` (and its `<label>`, if any - `Dropdown` renders its own via `Field`, so a wrapping/sibling label would otherwise duplicate) for `<Dropdown placeholder value onChange options>`, preserving default values and `onChange` behavior exactly - a styling fix, not a behavior change.

`ProblemList.tsx`'s Severity field (the same bug) is deliberately **not** included here - already fixed and pending merge in #3011.

## Why
User-reported: a screenshot of the Consents panel's native, unstyled dropdown. A scoping pass across the whole frontend confirmed the real scope (20 instances, not the "100+" initially estimated) before any fix work started.

## Impact area
`apps/frontend` only, across the 14 files listed above plus their test files.

## Validation performed
- Targeted Jest across all 14 touched components + their panel/page wrappers: 27 suites, 498 tests, all passing.
- `npx tsc --noemit` clean.
- `npx eslint` clean (zero warnings) on all 30 touched files.
- Every updated test (`userEvent.selectOptions` → button+listbox click pattern) verified live; two files (`CreateKeyForm.tsx`, `FederationSection.tsx`) had no pre-existing test coverage of the specific select field - confirmed via their test files rather than assumed, nothing was silently dropped.
- Mutation-tested the reported bug's own fix (`ConsentList.tsx`): broke the `onChange` wiring, confirmed the test fails, restored, confirmed green again.
- Visually verified the reported bug's fix live in Storybook: the Consent type field now renders as a themed button trigger, and its option panel matches the rest of the app (light card, blue-highlighted selection) instead of native OS dropdown chrome.