### PR TITLE
fix(frontend): floor negative available stock, block below-cost pricing

### DIFF
--- a/apps/frontend/src/app/__tests__/components/AddInventory/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/AddInventory/index.test.tsx
@@ -549,6 +549,46 @@ describe('AddInventory Component', () => {
     expect(screen.getByTestId('active-label')).toHaveTextContent('pricing');
   });
 
+  it('blocks a selling price below the purchase cost on the pricing step', () => {
+    render(<AddInventory {...props} />);
+
+    fireEvent.change(screen.getByTestId('in-name'), { target: { value: 'Item' } });
+    fireEvent.change(screen.getByTestId('in-cat'), { target: { value: 'Cat' } });
+    fireEvent.change(screen.getByTestId('in-reorder'), { target: { value: '5' } });
+
+    fireEvent.click(screen.getByTestId('save-btn')); // basic -> classification
+    fireEvent.click(screen.getByTestId('save-btn')); // classification -> batch
+    fireEvent.click(screen.getByTestId('save-btn')); // batch -> stock
+    fireEvent.click(screen.getByTestId('save-btn')); // stock -> pricing
+    expect(screen.getByTestId('active-label')).toHaveTextContent('pricing');
+
+    // Selling below purchase cost - both present and numeric, so this is the
+    // one case only the new cross-field check can catch.
+    fireEvent.change(screen.getByTestId('in-cost'), { target: { value: '20' } });
+    fireEvent.change(screen.getByTestId('in-sell'), { target: { value: '10' } });
+    fireEvent.click(screen.getByTestId('save-btn'));
+    expect(screen.getByTestId('active-label')).toHaveTextContent('pricing');
+  });
+
+  it('allows a selling price at or above the purchase cost through the pricing step', () => {
+    render(<AddInventory {...props} />);
+
+    fireEvent.change(screen.getByTestId('in-name'), { target: { value: 'Item' } });
+    fireEvent.change(screen.getByTestId('in-cat'), { target: { value: 'Cat' } });
+    fireEvent.change(screen.getByTestId('in-reorder'), { target: { value: '5' } });
+
+    fireEvent.click(screen.getByTestId('save-btn')); // basic -> classification
+    fireEvent.click(screen.getByTestId('save-btn')); // classification -> batch
+    fireEvent.click(screen.getByTestId('save-btn')); // batch -> stock
+    fireEvent.click(screen.getByTestId('save-btn')); // stock -> pricing
+
+    fireEvent.change(screen.getByTestId('in-cost'), { target: { value: '20' } });
+    fireEvent.change(screen.getByTestId('in-sell'), { target: { value: '20' } });
+    fireEvent.click(screen.getByTestId('save-btn'));
+    // Equal to cost is a valid (zero-margin) price, not a blocked one - advances off pricing.
+    expect(screen.getByTestId('active-label')).not.toHaveTextContent('pricing');
+  });
+
   it('validates the reorder level on the stock step', () => {
     render(<AddInventory {...props} />);
 

--- a/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
@@ -145,8 +145,17 @@ describe('Inventory Utils', () => {
       expect(result).toEqual({
         onHand: undefined,
         allocated: 5,
-        available: -5, // 0 - 5
+        // 0 - 5 = -5, floored to 0: "available" is a quantity someone can
+        // still take, so it never reads as negative even when allocation
+        // over-commits the on-hand count.
+        available: 0,
       });
+    });
+
+    it('floors available at zero when allocated exceeds on-hand', () => {
+      const batches: BatchValues[] = [{ quantity: '10', allocated: '25' } as BatchValues];
+      const result = calculateBatchTotals(batches);
+      expect(result).toEqual({ onHand: 10, allocated: 25, available: 0 });
     });
 
     it('ignores undefined values in summation', () => {
@@ -1021,6 +1030,12 @@ describe('inventory metric helpers', () => {
     expect(getAvailableStock(metricItem({ stock: { allocated: 5 } } as never))).toBeUndefined();
     // Missing allocated defaults to 0.
     expect(getAvailableStock(metricItem({ stock: { current: 7 } } as never))).toBe(7);
+  });
+
+  it('floors available stock at zero instead of showing a negative count', () => {
+    expect(getAvailableStock(metricItem({ stock: { current: 0, allocated: 10 } } as never))).toBe(
+      0
+    );
   });
 
   it('computes profit, margin, and markup with divide-by-zero guards', () => {

--- a/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
+++ b/apps/frontend/src/app/features/inventory/components/AddInventory/index.tsx
@@ -280,6 +280,12 @@ const useAddInventoryContent = ({
       errors.selling = 'Selling price is required';
     } else if (Number.isNaN(Number(pricing.selling))) {
       errors.selling = 'Enter a valid number';
+    } else if (
+      pricing.purchaseCost &&
+      !Number.isNaN(Number(pricing.purchaseCost)) &&
+      Number(pricing.selling) < Number(pricing.purchaseCost)
+    ) {
+      errors.selling = 'Selling price is below the purchase cost';
     }
     return errors;
   };

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -92,7 +92,12 @@ export const calculateBatchTotals = (
   if (hasOnHand || hasAllocated) {
     const onHandValue = hasOnHand ? onHand : 0;
     const allocatedValue = hasAllocated ? allocated : 0;
-    available = onHandValue - allocatedValue;
+    // Allocated can exceed on-hand (an over-allocation upstream), but "available"
+    // is a quantity someone can still take - it reads as nonsensical, not urgent,
+    // shown as negative. Floor at zero; the over-allocation itself is a separate,
+    // backend-side data question, not something this display should paper over
+    // by pretending it doesn't need a floor.
+    available = Math.max(0, onHandValue - allocatedValue);
   } else {
     available = undefined;
   }
@@ -703,7 +708,9 @@ export const getAvailableStock = (item: InventoryItem): number | undefined => {
   const onHand = toDisplayNumber(item.stock?.current);
   const allocated = toDisplayNumber(item.stock?.allocated) ?? 0;
   if (onHand === undefined) return undefined;
-  return onHand - allocated;
+  // See calculateBatchTotals above - over-allocation is a real, separate data
+  // problem, but "available" itself should never read as a negative quantity.
+  return Math.max(0, onHand - allocated);
 };
 
 export const getGrossProfitPerUnit = (item: InventoryItem): number | undefined => {
@@ -808,7 +815,9 @@ export const getDerivedStockHealth = (
  * An item at zero is below its reorder point by definition. This is the single
  * predicate both counts must agree on.
  */
-export const isBelowReorderPoint = (item: Parameters<typeof effectiveStockHealthKey>[0]): boolean => {
+export const isBelowReorderPoint = (
+  item: Parameters<typeof effectiveStockHealthKey>[0]
+): boolean => {
   const key = effectiveStockHealthKey(item);
   return key === 'LOW_STOCK' || key === 'OUT_OF_STOCK';
 };


### PR DESCRIPTION
## What changed

Two real data-integrity gaps from the Aug 13 QA pass (#2168), confirmed still present on `dev`:

- **Inventory could show negative "available" stock** (e.g. "0 on hand, -10 available") whenever allocated exceeds on-hand. "Available" is a quantity someone can still take - it reads as nonsensical rather than urgent when shown negative. Floored at zero in both `calculateBatchTotals` (the batch-totals summary shown while adding/editing batches) and `getAvailableStock` (the item-level metric helper). The stock-section's own inline handler in `AddInventory/index.tsx` already did exactly this (`Math.max(0, ...)`) - these two were the exceptions, not a new pattern. The over-allocation itself stays a separate, backend-side question this doesn't try to answer.
- **`validatePricing` had no cross-field check** - a selling price below purchase cost (a plausible decimal-point or swapped-field typo) saved without so much as a warning. Added a check consistent with this function's existing hard-block-on-error convention: every other pricing validation in this function already blocks the same way (missing/non-numeric cost or selling price).

## Testing

Guard tests added/updated for both, mutation-checked: reverted each fix in turn, confirmed the corresponding assertions failed (3 in `pages/Inventory/utils.test.ts`, 1 in `components/AddInventory/index.test.tsx`), restored, confirmed all pass again.

One pre-existing test asserted the old negative-availability value directly (`available: -5`) - updated to the new floored expectation rather than left contradicting the fix.

`tsc --noEmit`: clean. `eslint`: clean on touched files.

## Impact

Frontend only. Both are display/validation-layer fixes - no API or schema changes. Light-mode/normal-path behaviour is unchanged (only the negative/below-cost edge cases are affected).