### PR TITLE
fix(frontend): match MSD's connected-status wording to IDEXX's

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Integrations/index.test.tsx
@@ -443,9 +443,11 @@ describe('IntegrationsPage — enabled render', () => {
     expect(
       within(getCard('MSD Veterinary Manual')).getByRole('button', { name: 'Open manuals' })
     ).toBeInTheDocument();
-    // IDEXX reads as CONNECTED per the design; MSD keeps ENABLED.
+    // Both integrations read as CONNECTED when enabled - MSD used to fall through to
+    // the pill's raw-status-key default ("Enabled"), one word for the same state IDEXX
+    // spells "Connected".
     expect(within(getCard('IDEXX VetConnect PLUS')).getByText('Connected')).toBeInTheDocument();
-    expect(within(getCard('MSD Veterinary Manual')).getByText('Enabled')).toBeInTheDocument();
+    expect(within(getCard('MSD Veterinary Manual')).getByText('Connected')).toBeInTheDocument();
     await flush();
   });
 

--- a/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
+++ b/apps/frontend/src/app/features/integrations/pages/Integrations/index.tsx
@@ -1064,7 +1064,10 @@ const MerckIntegrationCard = ({
         <div className={INTEGRATION_CARD_TITLE_CLASS} style={INTEGRATION_CARD_TITLE_STYLE}>
           MSD Veterinary Manual
         </div>
-        <IntegrationStatusPill status={s.merckIntegration?.status} />
+        <IntegrationStatusPill
+          status={s.merckIntegration?.status}
+          label={s.merckEnabled ? 'Connected' : undefined}
+        />
       </div>
       <div className={INTEGRATION_CARD_DESC_CLASS} style={INTEGRATION_CARD_DESC_STYLE}>
         Search the veterinary manual from the workspace side rail without leaving the visit. Free


### PR DESCRIPTION
## What changed

Both integration cards on the Integrations page go through the same `IntegrationStatusPill`, but only `IdexxIntegrationCard` passed a `label` override (`label={idexxEnabled ? 'Connected' : undefined}`). `MerckIntegrationCard` passed none, so it fell through to the pill's own default (the raw status key, capitalized: `"Enabled"`). Two words for the identical connected state, on two cards in the same grid - from #2168's QA pass.

Added the same override to the MSD card (`s.merckEnabled ? 'Connected' : undefined`), which already had the underlying `merckEnabled` boolean available.

## Testing

An existing test had locked in the mismatch as intentional design (`// IDEXX reads as CONNECTED per the design; MSD keeps ENABLED.`) - updated the comment and its assertion, since the mismatch was the bug this fixes, not a deliberate choice.

Mutation-checked: reverted the `label` prop, confirmed the updated assertion fails, restored, confirmed it passes.

`tsc --noEmit`: clean. `eslint`: clean on touched files.

## Impact

One line of production code, one test file. No visual change beyond the MSD card's status pill text when connected ("Enabled" → "Connected").