### PR TITLE
fix(backend): make Stripe read-backs currency-aware

### DIFF
--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -13,7 +13,10 @@ import { prisma } from "src/config/prisma";
 import logger from "src/utils/logger";
 import { FinanceEventService } from "./events";
 import { roundMoney } from "./pricing";
-import { toStripeMinorUnits } from "src/utils/stripe-minor-units";
+import {
+  fromStripeMinorUnits,
+  toStripeMinorUnits,
+} from "src/utils/stripe-minor-units";
 import { markInvoiceTreatmentItemsSettled } from "./settlement";
 
 type PaymentLineSummary = {
@@ -71,6 +74,7 @@ type StripeCheckoutSessionClient = {
       id: string;
       status: string;
       amount: number;
+      currency: string;
     }>;
   };
 };
@@ -1497,7 +1501,9 @@ export const FinancePaymentService = {
 
       providerRefundId = refund.id;
       refundStatus = refund.status;
-      amountRefunded = roundMoney(refund.amount / 100);
+      amountRefunded = roundMoney(
+        fromStripeMinorUnits(refund.amount, refund.currency),
+      );
     }
 
     const refund = await prisma.refund.create({

--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -17,7 +17,10 @@ import { NotificationService } from "./notification.service";
 
 import { prisma } from "src/config/prisma";
 import { getOrgBillingCurrency } from "src/utils/billing";
-import { toStripeMinorUnits } from "src/utils/stripe-minor-units";
+import {
+  fromStripeMinorUnits,
+  toStripeMinorUnits,
+} from "src/utils/stripe-minor-units";
 import { recomputeOrganizationVerification } from "./organization-verification.service";
 import { Prisma } from "@prisma/client";
 
@@ -71,7 +74,10 @@ const resolveCapturedAmount = (
     return null;
   }
 
-  return capturedMinorUnits / 100;
+  return fromStripeMinorUnits(
+    capturedMinorUnits,
+    charge?.currency ?? pi.currency,
+  );
 };
 
 const isUniqueConstraintViolation = (error: unknown): boolean =>
@@ -579,7 +585,9 @@ export const StripeService = {
     // they render are projected out - never the session object itself.
     return {
       status: session.payment_status,
-      total: session.amount_total ? session.amount_total / 100 : 0,
+      total: session.amount_total
+        ? fromStripeMinorUnits(session.amount_total, session.currency ?? "usd")
+        : 0,
     };
   },
 
@@ -991,6 +999,7 @@ export const StripeService = {
 
   async _handleRefund(charge: Stripe.Charge) {
     const invoiceId = charge.metadata?.invoiceId;
+    const amount = fromStripeMinorUnits(charge.amount, charge.currency);
     const result = await FinancePaymentService.markInvoiceRefundedFromWebhook({
       invoiceId,
       paymentIntentId:
@@ -998,7 +1007,7 @@ export const StripeService = {
           ? charge.payment_intent
           : null,
       chargeId: charge.id,
-      amount: charge.amount / 100,
+      amount,
       currency: charge.currency,
       reason: charge.refunded ? "Refunded via Stripe" : undefined,
     });
@@ -1018,7 +1027,7 @@ export const StripeService = {
     }
 
     const notificationPayload = NotificationTemplates.Payment.REFUND_ISSUED(
-      charge.amount / 100,
+      amount,
       charge.currency,
     );
     await NotificationService.sendToUser(
@@ -1070,6 +1079,7 @@ export const StripeService = {
       return;
     }
 
+    const conversionCurrency = session.currency ?? "usd";
     const result =
       await FinancePaymentService.handleInvoiceCheckoutSessionCompleted({
         invoiceId,
@@ -1081,11 +1091,16 @@ export const StripeService = {
             : null,
         currency: session.currency ?? null,
         amountSubtotal: session.amount_subtotal
-          ? session.amount_subtotal / 100
+          ? fromStripeMinorUnits(session.amount_subtotal, conversionCurrency)
           : null,
-        amountTotal: session.amount_total ? session.amount_total / 100 : null,
+        amountTotal: session.amount_total
+          ? fromStripeMinorUnits(session.amount_total, conversionCurrency)
+          : null,
         amountTax: session.total_details?.amount_tax
-          ? session.total_details.amount_tax / 100
+          ? fromStripeMinorUnits(
+              session.total_details.amount_tax,
+              conversionCurrency,
+            )
           : null,
         automaticTaxStatus: session.automatic_tax?.status ?? null,
         rawProviderPayload: {

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -1581,6 +1581,7 @@ describe("FinancePaymentService", () => {
       id: "re_9",
       status: "succeeded",
       amount: 9000,
+      currency: "usd",
     });
     (prisma.payment.create as jest.Mock).mockResolvedValueOnce({
       id: "pay_9",
@@ -1637,6 +1638,68 @@ describe("FinancePaymentService", () => {
     );
     expect(result.refund.refundId).toBe("re_9");
     expect(result.invoice.status).toBe("REFUNDED");
+  });
+
+  it("keeps a zero-decimal Stripe invoice refund amount unscaled", async () => {
+    const stripeClient = {
+      checkout: { sessions: { create: jest.fn(), expire: jest.fn() } },
+      paymentIntents: { create: jest.fn(), retrieve: jest.fn() },
+      refunds: { create: jest.fn() },
+    };
+    __setFinanceStripeClientForTests(stripeClient);
+    (prisma.invoice.findUnique as jest.Mock).mockResolvedValueOnce({
+      id: "inv_jpy",
+      organisationId: "org_1",
+      totalAmount: 1000,
+      currency: "jpy",
+      status: "PAID",
+      metadata: {},
+      payments: [],
+    });
+    (prisma.paymentAttempt.findFirst as jest.Mock)
+      .mockResolvedValueOnce({ providerPaymentIntentId: "pi_jpy" })
+      .mockResolvedValueOnce({
+        invoiceId: "inv_jpy",
+        rawProviderPayload: { connectedAccountId: "acct_jpy" },
+      });
+    (stripeClient.paymentIntents.retrieve as jest.Mock).mockResolvedValueOnce({
+      latest_charge: "ch_jpy",
+    });
+    (stripeClient.refunds.create as jest.Mock).mockResolvedValueOnce({
+      id: "re_jpy",
+      status: "succeeded",
+      amount: 1000,
+      currency: "jpy",
+    });
+    (prisma.payment.create as jest.Mock).mockResolvedValueOnce({
+      id: "pay_jpy",
+      amount: 1000,
+      currency: "jpy",
+      provider: "STRIPE",
+    });
+    (prisma.refund.create as jest.Mock).mockResolvedValueOnce({
+      id: "refund_jpy",
+      status: "SUCCEEDED",
+    });
+    (prisma.payment.update as jest.Mock).mockResolvedValueOnce({
+      id: "pay_jpy",
+      status: "REFUNDED",
+    });
+    (prisma.invoice.update as jest.Mock).mockResolvedValueOnce({
+      id: "inv_jpy",
+      status: "REFUNDED",
+      currency: "jpy",
+      payments: [],
+    });
+
+    const result = await FinancePaymentService.refundInvoicePayment("inv_jpy");
+
+    expect(prisma.refund.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({ amount: 1000, currency: "jpy" }),
+      }),
+    );
+    expect(result.refund.amountRefunded).toBe(1000);
   });
 
   it("refunds a payment by payment id", async () => {
@@ -4953,6 +5016,7 @@ describe("FinancePaymentService", () => {
       id: "re_t",
       status: "succeeded",
       amount: 9000,
+      currency: "usd",
     });
     (prisma.refund.create as jest.Mock).mockResolvedValueOnce({
       id: "refund_t",

--- a/apps/backend/test/services/stripe.service.test.ts
+++ b/apps/backend/test/services/stripe.service.test.ts
@@ -8,6 +8,7 @@ import {
 } from "../../src/services/finance/payment";
 import { FinanceSubscriptionService } from "../../src/services/finance/subscription";
 import { NotificationService } from "../../src/services/notification.service";
+import { NotificationTemplates } from "../../src/utils/notificationTemplates";
 import logger from "../../src/utils/logger";
 import { recomputeOrganizationVerification } from "../../src/services/organization-verification.service";
 import { prisma } from "src/config/prisma";
@@ -655,6 +656,18 @@ describe("StripeService", () => {
 
       const result = await StripeService.retrieveCheckoutSession("sess_1");
       expect(result).toEqual({ status: "paid", total: 123 });
+    });
+
+    it("keeps zero-decimal checkout session totals unscaled", async () => {
+      mStripe.checkout.sessions.retrieve.mockResolvedValueOnce({
+        payment_status: "paid",
+        amount_total: 12300,
+        currency: "jpy",
+      });
+
+      const result = await StripeService.retrieveCheckoutSession("sess_jpy");
+
+      expect(result).toEqual({ status: "paid", total: 12300 });
     });
 
     it("retrieves the session on the connected account it was created on", async () => {
@@ -1888,6 +1901,37 @@ describe("StripeService", () => {
       expect(logger.info).toHaveBeenCalledWith("Invoice inv_1 marked PAID");
     });
 
+    it("keeps a zero-decimal captured amount unscaled", async () => {
+      (
+        FinancePaymentService.handleInvoicePaymentIntentSucceeded as jest.Mock
+      ).mockResolvedValueOnce({
+        action: "PAID",
+        invoice: {
+          id: "inv_jpy",
+          parentId: "p",
+          totalAmount: 5000,
+          currency: "jpy",
+        },
+      });
+      mStripe.charges.retrieve.mockResolvedValueOnce({
+        id: "ch_jpy",
+        receipt_url: "r",
+        amount_captured: 5000,
+        currency: "jpy",
+      });
+
+      await StripeService._handleInvoicePayment({
+        id: "pi_jpy",
+        currency: "jpy",
+        latest_charge: "ch_jpy",
+        metadata: { invoiceId: "inv_jpy" },
+      } as any);
+
+      expect(
+        FinancePaymentService.handleInvoicePaymentIntentSucceeded,
+      ).toHaveBeenCalledWith(expect.objectContaining({ amount: 5000 }));
+    });
+
     it("falls back to amount_received when there is no charge", async () => {
       (
         FinancePaymentService.handleInvoicePaymentIntentSucceeded as jest.Mock
@@ -2027,6 +2071,31 @@ describe("StripeService", () => {
   });
 
   describe("_handleRefund guards", () => {
+    it("keeps zero-decimal refund ledger and notification amounts unscaled", async () => {
+      (
+        FinancePaymentService.markInvoiceRefundedFromWebhook as jest.Mock
+      ).mockResolvedValueOnce({
+        action: "REFUNDED",
+        invoice: { id: "inv_jpy", parentId: "par_jpy" },
+      });
+
+      await StripeService._handleRefund({
+        id: "ch_jpy",
+        payment_intent: "pi_jpy",
+        amount: 1000,
+        currency: "jpy",
+        metadata: { invoiceId: "inv_jpy" },
+      } as any);
+
+      expect(
+        FinancePaymentService.markInvoiceRefundedFromWebhook,
+      ).toHaveBeenCalledWith(expect.objectContaining({ amount: 1000 }));
+      expect(NotificationTemplates.Payment.REFUND_ISSUED).toHaveBeenCalledWith(
+        1000,
+        "jpy",
+      );
+    });
+
     it("logs loudly when a refund matches no invoice", async () => {
       /*
        * The customer has their money back and no invoice moved to REFUNDED, so
@@ -2363,6 +2432,35 @@ describe("StripeService", () => {
       expect(NotificationService.sendToUser).toHaveBeenCalledWith(
         "par_1",
         "mock-success-payload",
+      );
+    });
+
+    it("keeps zero-decimal checkout subtotal, total, and tax unscaled", async () => {
+      (
+        FinancePaymentService.handleInvoiceCheckoutSessionCompleted as jest.Mock
+      ).mockResolvedValueOnce({
+        action: "IGNORED",
+        invoice: { id: "inv_jpy" },
+      });
+
+      await StripeService._handleInvoiceCheckout({
+        id: "cs_jpy",
+        payment_status: "paid",
+        currency: "jpy",
+        amount_subtotal: 9000,
+        amount_total: 10000,
+        total_details: { amount_tax: 1000 },
+        metadata: { invoiceId: "inv_jpy" },
+      } as any);
+
+      expect(
+        FinancePaymentService.handleInvoiceCheckoutSessionCompleted,
+      ).toHaveBeenCalledWith(
+        expect.objectContaining({
+          amountSubtotal: 9000,
+          amountTotal: 10000,
+          amountTax: 1000,
+        }),
       );
     });
   });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## What is the current behavior?

Stripe payment, checkout, and refund read-backs divide provider amounts by 100 even when the response currency is zero-decimal. A JPY amount of 1000 can therefore be recorded or returned as 10.

## What is the new behavior?

- Converts all eight affected Stripe read boundaries through the shared currency-aware minor-unit helper.
- Keeps USD behavior unchanged while preserving zero-decimal JPY amounts.
- Adds focused JPY coverage for captured payments, checkout totals and tax, refund persistence, and refund notifications.
- Validated 246 focused tests with 99.74% statements and lines across the two touched services; all eight legacy `/ 100` mutations fail their corresponding new assertions.
- Backend lint, type-check, and build pass. The pre-push monorepo lint and type-check gates also pass. The full backend suite requires a local Redis service and remains delegated to hosted CI.

## Related Issue(s)

Fixes #3021
