### PR TITLE
fix(frontend): show live password strength while signing up or resetting

### DIFF
--- a/apps/frontend/src/app/__tests__/features/auth/lib/passwordStrength.test.ts
+++ b/apps/frontend/src/app/__tests__/features/auth/lib/passwordStrength.test.ts
@@ -1,0 +1,45 @@
+import {
+  PASSWORD_STRENGTH_MAX_SCORE,
+  isStrongPassword,
+  passwordStrengthLabel,
+  scorePassword,
+} from '@/app/features/auth/lib/passwordStrength';
+
+describe('scorePassword', () => {
+  it('scores an empty password at zero', () => {
+    expect(scorePassword('')).toBe(0);
+  });
+
+  it('gives one point per missing criterion', () => {
+    expect(scorePassword('short')).toBe(1); // lowercase only, under 8 chars
+    expect(scorePassword('longenough')).toBe(2); // 8+ chars, lowercase
+    expect(scorePassword('Longenough')).toBe(3); // + uppercase
+    expect(scorePassword('Longenough1')).toBe(4); // + digit
+  });
+
+  it('reaches the max score only once every criterion is met', () => {
+    expect(scorePassword('Longenough1!')).toBe(PASSWORD_STRENGTH_MAX_SCORE);
+  });
+});
+
+describe('passwordStrengthLabel', () => {
+  it('labels each score band', () => {
+    expect(passwordStrengthLabel(0)).toBe('Too weak');
+    expect(passwordStrengthLabel(2)).toBe('Too weak');
+    expect(passwordStrengthLabel(3)).toBe('Weak');
+    expect(passwordStrengthLabel(4)).toBe('Fair');
+    expect(passwordStrengthLabel(5)).toBe('Strong');
+  });
+});
+
+describe('isStrongPassword', () => {
+  it('matches the same requirement SignUp/ResetPassword show in their error copy', () => {
+    // "at least 8 characters long, include uppercase, lowercase, number, and special character"
+    expect(isStrongPassword('Longenough1!')).toBe(true);
+    expect(isStrongPassword('longenough1!')).toBe(false); // no uppercase
+    expect(isStrongPassword('LONGENOUGH1!')).toBe(false); // no lowercase
+    expect(isStrongPassword('Longenough!')).toBe(false); // no digit
+    expect(isStrongPassword('Longenough1')).toBe(false); // no special char
+    expect(isStrongPassword('Nope 1!')).toBe(false); // under 8 chars
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/ResetPassword/ResetPassword.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/ResetPassword/ResetPassword.test.tsx
@@ -202,4 +202,22 @@ describe('ResetPassword landing page', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
+  it('shows a live password strength readout on the new-password field only', () => {
+    render(<ResetPassword />);
+    expect(screen.queryByText(/password strength/i)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('New password'), { target: { value: 'weak' } });
+    expect(screen.getByText('Password strength: Too weak')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('New password'), {
+      target: { value: 'Test-password-3!' },
+    });
+    expect(screen.getByText('Password strength: Strong')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText('Confirm password'), {
+      target: { value: 'Test-password-3!' },
+    });
+    expect(screen.getAllByText(/password strength/i)).toHaveLength(1);
+  });
 });

--- a/apps/frontend/src/app/__tests__/pages/SignUp.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/SignUp.test.tsx
@@ -237,6 +237,23 @@ describe('SignUp page', () => {
     const results = await axe(container);
     expect(results).toHaveNoViolations();
   });
+
+  test('shows a live password strength readout that improves as the password does', () => {
+    render(<SignUp />);
+    expect(screen.queryByText(/password strength/i)).not.toBeInTheDocument();
+
+    setFieldValue('Set up password', 'short');
+    expect(screen.getByText('Password strength: Too weak')).toBeInTheDocument();
+
+    setFieldValue('Set up password', 'Secret!23');
+    expect(screen.getByText('Password strength: Strong')).toBeInTheDocument();
+  });
+
+  test('does not show a strength readout on the confirm-password field', () => {
+    render(<SignUp />);
+    setFieldValue('Confirm password', 'Secret!23');
+    expect(screen.queryByText(/password strength/i)).not.toBeInTheDocument();
+  });
 });
 
 describe('auth-brand headline reads the fixed accent-dark token', () => {

--- a/apps/frontend/src/app/features/auth/lib/passwordStrength.ts
+++ b/apps/frontend/src/app/features/auth/lib/passwordStrength.ts
@@ -1,0 +1,31 @@
+/**
+ * Scores a password against the same five checks SignUp/ResetPassword already
+ * enforce on submit (length, lower, upper, digit, special char), so the score
+ * hitting its max is exactly "will pass validation" - not a second, unrelated
+ * notion of strength the user has to reconcile against the submit error.
+ */
+
+const CRITERIA: ReadonlyArray<(password: string) => boolean> = [
+  (password) => password.length >= 8,
+  (password) => /[a-z]/.test(password),
+  (password) => /[A-Z]/.test(password),
+  (password) => /\d/.test(password),
+  (password) => /[^\w\s]/.test(password),
+];
+
+export const PASSWORD_STRENGTH_MAX_SCORE = CRITERIA.length;
+
+export const scorePassword = (password: string): number =>
+  CRITERIA.filter((meets) => meets(password)).length;
+
+export type PasswordStrengthLabel = 'Too weak' | 'Weak' | 'Fair' | 'Strong';
+
+export const passwordStrengthLabel = (score: number): PasswordStrengthLabel => {
+  if (score <= 2) return 'Too weak';
+  if (score === 3) return 'Weak';
+  if (score === 4) return 'Fair';
+  return 'Strong';
+};
+
+export const isStrongPassword = (password: string): boolean =>
+  scorePassword(password) === PASSWORD_STRENGTH_MAX_SCORE;

--- a/apps/frontend/src/app/features/auth/pages/ResetPassword/ResetPassword.tsx
+++ b/apps/frontend/src/app/features/auth/pages/ResetPassword/ResetPassword.tsx
@@ -20,8 +20,7 @@ import {
   AuthPasswordField,
   AuthSubmitButton,
 } from '@/app/features/auth/pages/authForm';
-
-const STRONG_PASSWORD_REGEX = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s]).{8,}$/;
+import { isStrongPassword } from '@/app/features/auth/lib/passwordStrength';
 
 const RESET_POINTS = [
   {
@@ -91,7 +90,7 @@ const getPasswordValidationErrors = (
       ...(confirmPassword ? {} : { confirmPassword: 'Confirm your new password' }),
     };
   }
-  if (!STRONG_PASSWORD_REGEX.test(password)) {
+  if (!isStrongPassword(password)) {
     return {
       password:
         'Password must be at least 8 characters long, include uppercase, lowercase, number, and special character',
@@ -238,6 +237,7 @@ const ResetPassword = () => {
                   setPassword(value);
                   setInputErrors({});
                 }}
+                showStrength
               />
               <AuthPasswordField
                 id="reset-confirm"

--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.tsx
@@ -15,6 +15,7 @@ import { useErrorTost } from '@/app/ui/overlays/Toast/Toast';
 import { useAuthStore } from '@/app/stores/authStore';
 import OtpModal from '@/app/ui/overlays/OtpModal/OtpModal';
 import { getEmailValidationError, normalizeEmail } from '@/app/lib/validators';
+import { isStrongPassword } from '@/app/features/auth/lib/passwordStrength';
 import { YosemiteLoader } from '@/app/ui/overlays/Loader';
 import { useSignUpDraft } from '@/app/hooks/useSignUpDraft';
 import { setStorageItem } from '@/app/lib/browserStorage';
@@ -94,8 +95,6 @@ const passwordErrors = (
   password: string,
   confirmPassword: string
 ): { pError?: string; confirmPError?: string } => {
-  const strongPasswordRegex = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s]).{8,}$/;
-
   if (!password) {
     return {
       pError: 'Password is required',
@@ -103,7 +102,7 @@ const passwordErrors = (
     };
   }
 
-  if (!strongPasswordRegex.test(password)) {
+  if (!isStrongPassword(password)) {
     return {
       pError:
         'Password must be at least 8 characters long, include uppercase, lowercase, number, and special character',
@@ -322,6 +321,7 @@ const SignUpFields = ({
       onChange={onPasswordChange}
       showPassword={showPassword}
       onToggleShowPassword={onToggleShowPassword}
+      showStrength
     />
     <AuthTextField
       id="signup-confirm-password"

--- a/apps/frontend/src/app/features/auth/pages/authForm.tsx
+++ b/apps/frontend/src/app/features/auth/pages/authForm.tsx
@@ -8,6 +8,11 @@ import {
   IoEyeOutline,
   IoPhonePortraitOutline,
 } from 'react-icons/io5';
+import {
+  PASSWORD_STRENGTH_MAX_SCORE,
+  passwordStrengthLabel,
+  scorePassword,
+} from '@/app/features/auth/lib/passwordStrength';
 
 /**
  * Shared building blocks for the sign in / sign up screens. Both pages render the
@@ -74,6 +79,32 @@ const toggleButtonStyle: CSSProperties = {
   display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
+};
+
+const strengthMeterStyle: CSSProperties = {
+  display: 'flex',
+  gap: 5,
+  marginTop: 2,
+};
+
+const strengthBarStyle: CSSProperties = {
+  flex: 1,
+  height: 4,
+  borderRadius: 2,
+  background: 'var(--hairline)',
+};
+
+const strengthLabelStyle: CSSProperties = {
+  fontSize: 12.5,
+  color: 'var(--ink-faint)',
+  letterSpacing: '-0.01em',
+};
+
+const STRENGTH_BAR_COLOR: Record<string, string> = {
+  'Too weak': 'var(--color-danger-500)',
+  Weak: 'var(--color-warning-500)',
+  Fair: 'var(--color-warning-300)',
+  Strong: 'var(--color-success-600)',
 };
 
 const submitButtonStyle: CSSProperties = {
@@ -198,6 +229,28 @@ export const AuthTextField = ({
   );
 };
 
+const PasswordStrengthMeter = ({ password }: Readonly<{ password: string }>) => {
+  const score = scorePassword(password);
+  const label = passwordStrengthLabel(score);
+  const filledBars = Math.max(1, Math.ceil((score / PASSWORD_STRENGTH_MAX_SCORE) * 4));
+  return (
+    <div aria-live="polite">
+      <div style={strengthMeterStyle} aria-hidden="true">
+        {[0, 1, 2, 3].map((barIndex) => (
+          <div
+            key={barIndex}
+            style={{
+              ...strengthBarStyle,
+              background: barIndex < filledBars ? STRENGTH_BAR_COLOR[label] : 'var(--hairline)',
+            }}
+          />
+        ))}
+      </div>
+      <span style={strengthLabelStyle}>Password strength: {label}</span>
+    </div>
+  );
+};
+
 interface AuthPasswordFieldProps {
   id: string;
   label: string;
@@ -211,6 +264,7 @@ interface AuthPasswordFieldProps {
   placeholder: string;
   error?: string;
   labelAccessory?: ReactNode;
+  showStrength?: boolean;
 }
 
 export const AuthPasswordField = ({
@@ -226,6 +280,7 @@ export const AuthPasswordField = ({
   placeholder,
   error,
   labelAccessory,
+  showStrength,
 }: Readonly<AuthPasswordFieldProps>) => {
   const errorId = `${id}-error`;
   return (
@@ -260,6 +315,7 @@ export const AuthPasswordField = ({
           )}
         </button>
       </div>
+      {showStrength && value ? <PasswordStrengthMeter password={value} /> : null}
       <FieldError id={errorId} message={error} />
     </div>
   );


### PR DESCRIPTION
## Summary

- Sign-up and reset-password only told the user their password was too weak after they hit submit — no live feedback while typing.
- Adds a live strength meter (Too weak / Weak / Fair / Strong) to `AuthPasswordField`, gated behind a new `showStrength` prop, wired on the two real new-password entry points (`SignUp`, `ResetPassword`) but not their confirm-password siblings.
- The meter is driven by the same five checks (length, lower, upper, digit, special char) the submit validation already enforces, so "Strong" means "will pass" rather than a second, unrelated notion of strength competing with the existing error copy.
- Dedupes the previously copy-pasted strong-password regex (identical in both `SignUp.tsx` and `ResetPassword.tsx`) into one shared, tested helper (`passwordStrength.ts`) both pages now call — a value-preserving refactor, not a behavior change.
- No new dependency: checked the monorepo for `zxcvbn`/similar first — none exists — so this uses the existing validation criteria rather than adding one for a small heuristic.

Part of the issue #2168 QA sweep.

## Test plan
- [x] `passwordStrength.ts` unit tests (score bands, `isStrongPassword` parity with the old regex's requirement text)
- [x] `SignUp`/`ResetPassword` tests: meter appears on the primary password field, absent on confirm-password, updates live as strength changes
- [x] Mutation-checked both the scoring bands and the `showStrength` gate (confirm-field exclusion) — reverting either breaks a real assertion
- [x] Live-verified in browser: dark and light mode, meter fills/colors correctly from "Too weak" to "Strong" on both SignUp and ResetPassword
- [x] `check-hardcoded-colours.mjs`: 0 to migrate (new styling uses only existing `var()` tokens)