### PR TITLE
fix(frontend): stop reverting the active org on an ordinary re-auth

### DIFF
--- a/apps/frontend/src/app/__tests__/stores/orgStore.test.ts
+++ b/apps/frontend/src/app/__tests__/stores/orgStore.test.ts
@@ -248,6 +248,43 @@ describe('Organization Store', () => {
       expect(useOrgStore.getState().primaryOrgId).toBe('org-1'); // Fallback to first available
     });
 
+    it('restores the last active org from storage when primaryOrgId was wiped but the org is still in the list', () => {
+      // Mirrors what a transient auth-check failure does: axios.ts's 401
+      // handler treats a failed session *check* the same as a real logout and
+      // wipes primaryOrgId to null, even though the user never signed out.
+      const store = useOrgStore.getState();
+      store.setOrgs([mockOrg1, mockOrg2]);
+      store.setPrimaryOrg('org-2');
+
+      useOrgStore.setState({ primaryOrgId: null });
+
+      store.setOrgs([mockOrg1, mockOrg2], { keepPrimaryIfPresent: true });
+
+      expect(useOrgStore.getState().primaryOrgId).toBe('org-2');
+    });
+
+    it('falls back to the first org when the last active org is no longer in the new list', () => {
+      const store = useOrgStore.getState();
+      store.setOrgs([mockOrg1, mockOrg2]);
+      store.setPrimaryOrg('org-2');
+
+      useOrgStore.setState({ primaryOrgId: null });
+
+      // A different user's org list (or org-2 was removed) - org-2 isn't in it.
+      store.setOrgs([mockOrg1], { keepPrimaryIfPresent: true });
+
+      expect(useOrgStore.getState().primaryOrgId).toBe('org-1');
+    });
+
+    it('falls back to the first org when there is no stored last-active org at all', () => {
+      const store = useOrgStore.getState();
+      localStorage.clear();
+
+      store.setOrgs([mockOrg1, mockOrg2], { keepPrimaryIfPresent: true });
+
+      expect(useOrgStore.getState().primaryOrgId).toBe('org-1');
+    });
+
     it('updates primary org when the current primary is removed', () => {
       const store = useOrgStore.getState();
       store.setOrgs([mockOrg1, mockOrg2]);

--- a/apps/frontend/src/app/stores/orgStore.ts
+++ b/apps/frontend/src/app/stores/orgStore.ts
@@ -1,9 +1,23 @@
 import { create } from 'zustand';
 import { createJSONStorage, persist } from 'zustand/middleware';
 import { Organisation, UserOrganization } from '@yosemite-crew/types';
-import { getPersistStorage } from '@/app/lib/browserStorage';
+import { getPersistStorage, getStorageItem, setStorageItem } from '@/app/lib/browserStorage';
 
 type OrgStatus = 'idle' | 'loading' | 'loaded' | 'error';
+
+// A transient failure of the session *check* itself (see axios.ts's 401
+// handler) is treated the same as a genuine logout: it wipes primaryOrgId
+// along with the rest of session state even though the user never actually
+// signed out. That leaves setOrgs's "keep the current primary" path with
+// nothing to keep, so it falls back to picking orgIds[0] - silently
+// switching the user's active org on an ordinary re-auth. This key is
+// deliberately NOT part of the zustand `persist` blob below (which the
+// session-reset path wipes wholesale via removeStorageItem('org-store')),
+// so it survives that wipe and lets setOrgs restore the real last-active
+// org - but only when the id is still present in the freshly-fetched org
+// list, so a different user on a shared browser can never be routed into
+// an org they don't actually belong to.
+const LAST_ACTIVE_ORG_ID_KEY = 'yc_last_active_org_id';
 
 // The backend's org list responses (e.g. mapOrganizationFromPrisma) include raw
 // integration credentials that no frontend code ever reads. This store's
@@ -72,9 +86,16 @@ export const useOrgStore = create<OrgState>()(
             primaryOrgId = orgIds.includes(state.primaryOrgId)
               ? state.primaryOrgId
               : (orgIds[0] ?? null);
+          } else if (opts?.keepPrimaryIfPresent) {
+            const lastActiveOrgId = getStorageItem('local', LAST_ACTIVE_ORG_ID_KEY);
+            primaryOrgId =
+              lastActiveOrgId && orgIds.includes(lastActiveOrgId)
+                ? lastActiveOrgId
+                : (orgIds[0] ?? null);
           } else {
             primaryOrgId = orgIds[0] ?? null;
           }
+          if (primaryOrgId) setStorageItem('local', LAST_ACTIVE_ORG_ID_KEY, primaryOrgId);
           return {
             orgsById,
             orgIds,
@@ -130,6 +151,7 @@ export const useOrgStore = create<OrgState>()(
           if (orgId && !state.orgsById[orgId]) {
             return state;
           }
+          if (orgId) setStorageItem('local', LAST_ACTIVE_ORG_ID_KEY, orgId);
           return {
             primaryOrgId: orgId,
           };


### PR DESCRIPTION
## Summary

- Root cause traced through `axios.ts`'s 401 handler → `hardSignOut()` → `resetSessionStores.ts`'s `clearSessionScopedStores()` → `orgStore.ts`'s `setOrgs`: a transient failure of the session **check** itself (`Session.doesSessionExist()` throwing) is treated identically to a genuine logout. That wipes `primaryOrgId` along with the rest of session state even though the user never actually signed out, so the next org fetch's "keep the current primary" logic has nothing to keep and silently falls back to `orgIds[0]` — switching a mid-route user's active org without asking.
- Fix: `orgStore.ts` now tracks the last active org in a standalone `localStorage` key, written on every primary-org change, deliberately outside the zustand `persist` blob the session-reset path wipes wholesale. `setOrgs` restores from it when the in-memory `primaryOrgId` is empty — but only when that org id is still present in the freshly-fetched list, so a different user on a shared browser can never be routed into an org they don't actually belong to.
- No changes needed to `resetSessionStores.ts` or `orgService.ts` — the fix is fully contained in `orgStore.ts` since the new key was never being cleared by the existing session-reset path in the first place.

Part of the issue #2168 QA sweep — flagged in an earlier pass as needing its own dedicated pass rather than a quick patch, since it touches core session lifecycle.

## Test plan
- [x] 3 new `orgStore` tests: restores the last-active org across a `primaryOrgId` wipe, falls back to `orgIds[0]` when that org is no longer in the new list, falls back to `orgIds[0]` when there's no stored value at all
- [x] Mutation-checked: reverting the restore logic breaks the new "restores after wipe" test
- [x] All 28 pre-existing `orgStore` tests still pass unchanged
- [x] `check-hardcoded-colours.mjs`: 0 to migrate (no styling touched)