### PR TITLE
fix(backend): set paidAt when minting a booking invoice already PAID

### DIFF
--- a/apps/backend/src/services/stripe.service.ts
+++ b/apps/backend/src/services/stripe.service.ts
@@ -159,6 +159,12 @@ const mintBookingInvoice = async (params: {
         patientId: patientId ?? undefined,
         currency: pi.currency ?? "usd",
         status: "PAID",
+        // Every other path that marks an invoice PAID sets paidAt in the same
+        // write (see updateInvoiceAfterPayment in finance/payment.ts) - this
+        // is the one that minted the invoice already-PAID and skipped it,
+        // which left paidAt-only queries like dashboard.service.ts's revenue
+        // aggregation silently dropping these invoices forever.
+        paidAt: new Date(),
         providerPaymentIntentId: pi.id,
         items: [
           {

--- a/apps/backend/test/services/stripe.service.test.ts
+++ b/apps/backend/test/services/stripe.service.test.ts
@@ -1238,6 +1238,13 @@ describe("StripeService", () => {
 
       expect(prisma.invoice.create).toHaveBeenCalled();
       expect(prisma.appointment.updateMany).toHaveBeenCalled();
+      // A minted invoice is already status: "PAID" - dashboard.service.ts's
+      // revenue queries filter on paidAt with no createdAt fallback, so a
+      // missing paidAt here would silently drop this invoice from revenue
+      // reporting forever.
+      const createCall = (prisma.invoice.create as jest.Mock).mock.calls[0][0];
+      expect(createCall.data.status).toBe("PAID");
+      expect(createCall.data.paidAt).toBeInstanceOf(Date);
     });
 
     it("settles open invoice for appointment booking payment", async () => {


### PR DESCRIPTION
## Summary

- `mintBookingInvoice` (`apps/backend/src/services/stripe.service.ts`) creates a brand-new invoice with `status: "PAID"` the instant a booking payment succeeds, but never set `paidAt` — every other path that marks an invoice PAID sets both fields in the same write (see `updateInvoiceAfterPayment` in `finance/payment.ts`).
- `paidAt` is nullable with no default (`packages/database/prisma/schema.prisma`), so these invoices silently dropped out of any `paidAt`-filtered query with no `createdAt` fallback — most consequentially `dashboard.service.ts`'s revenue-collected aggregations, which filter `paidAt >= from AND paidAt <= to` with no fallback at all.
- Fixed by setting `paidAt: new Date()` at invoice-creation time, matching the semantics `finance/payment.ts` already uses when no explicit `receivedAt` is supplied.

Found investigating the issue #2168 QA item on the finance dashboard showing "$0 collected this week". That specific frontend widget already has a `createdAt` fallback (`apps/frontend/src/app/lib/financeMetrics.ts`) so it wasn't reproducible from this gap alone — but the dashboard revenue queries have no such fallback and are directly affected by this bug.

## Test plan
- [x] Extended the existing "handles appointment booking payment" test in `stripe.service.test.ts` to assert `paidAt` is a `Date` on the created invoice
- [x] Mutation-checked: reverting the fix breaks the new assertion (`Received value has no prototype`)
- [x] Full `stripe.service.test.ts` suite passes (119/119)
- [x] `tsc --noEmit` and `eslint` clean on the touched files