### PR TITLE
fix(backend): complete documented local startup config

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,8 @@ cp apps/frontend/.env.example apps/frontend/.env
 
 Configure PostgreSQL, Redis, authentication, and the integrations you will use. Make `DATABASE_URL` and `DIRECT_URL` available in the shell that runs Prisma commands; app-specific `.env` files are not automatically loaded by every workspace command. Never use production credentials for local setup.
 
+Use separate PostgreSQL databases for the application and a self-hosted SuperTokens core. Stream chat is optional for local work: leaving its two server credentials blank keeps the API bootable and records the upload-policy control as skipped, while chat operations remain unavailable until configured.
+
 Generate the Prisma client:
 
 ```shell

--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -2,6 +2,23 @@ PORT="4000"
 APP_NAME="Yosemite"
 NODE_ENV="development"
 
+# --- Core services ----------------------------------------------------------
+# Application database. A self-hosted SuperTokens core must use a separate
+# database so its tables do not make the Prisma migration baseline non-empty.
+DATABASE_URL=""
+DIRECT_URL=""
+# Redis is required by the BullMQ job queues. Leave the password commented when
+# the local server does not require authentication.
+REDIS_HOST="127.0.0.1"
+REDIS_PORT="6379"
+# REDIS_PASSWORD=""
+
+# --- Optional Stream chat ---------------------------------------------------
+# Leave both blank when not working on chat. The API still starts and reports
+# the upload-policy control as skipped; chat operations require both values.
+STREAM_API_KEY=""
+STREAM_API_SECRET=""
+
 # --- Auth (provider-neutral boundary, #1672) -------------------------------
 # Provider selection; supertokens is the only implemented provider.
 AUTH_PROVIDER="supertokens"

--- a/apps/backend/README.md
+++ b/apps/backend/README.md
@@ -27,6 +27,8 @@ pnpm --filter backend run dev
 
 `LOCAL_DEVELOPMENT=true` switches on local-only behaviour: it opens CORS to `localhost:3000` (`src/app.ts`) and mounts the local-only MFA debug endpoint `POST /v1/auth/mfa/totp/debug/create-device`, which creates a TOTP device without the full enrolment flow. Both are keyed on this flag rather than on `NODE_ENV`, so a deployed tier running `NODE_ENV=development` never gets them. Set it only for a local run.
 
+Copy `.env.example` before starting. Its database variables target the application database, not the database used by a self-hosted SuperTokens core; Redis is required, while Stream chat credentials may stay blank unless you are working on chat.
+
 ## Running tests
 
 ```bash

--- a/apps/backend/src/config/stream-client.ts
+++ b/apps/backend/src/config/stream-client.ts
@@ -1,0 +1,10 @@
+import { StreamChat } from "stream-chat";
+
+export const getStreamServer = (): StreamChat => {
+  const key = process.env.STREAM_API_KEY;
+  const secret = process.env.STREAM_API_SECRET;
+  if (!key || !secret) {
+    throw new Error("Stream Chat credentials missing in env");
+  }
+  return StreamChat.getInstance(key, secret);
+};

--- a/apps/backend/src/controllers/app/chatWebhook.controller.ts
+++ b/apps/backend/src/controllers/app/chatWebhook.controller.ts
@@ -1,11 +1,8 @@
 // src/controllers/app/chatWebhook.controller.ts
 import type { Request, Response } from "express";
-import { StreamChat } from "stream-chat";
 import { scanAttachmentUrl } from "src/services/attachmentScanner.service";
+import { getStreamServer } from "src/config/stream-client";
 import logger from "src/utils/logger";
-
-const STREAM_KEY = process.env.STREAM_API_KEY!;
-const STREAM_SECRET = process.env.STREAM_API_SECRET!;
 
 type StreamAttachment = { asset_url?: string; image_url?: string };
 type StreamWebhookEvent = {
@@ -45,7 +42,7 @@ export const scanMessageAttachments = async (
         `Unsafe chat attachment on message ${messageId.replace(/[\n\r]/g, "")} (${result.threat}); deleting message`,
       );
       try {
-        const client = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
+        const client = getStreamServer();
         await client.deleteMessage(messageId, true);
       } catch (err) {
         logger.error("Failed to delete malicious chat message", err);
@@ -71,7 +68,7 @@ export const ChatWebhookController = {
       ? rawBody.toString("utf8")
       : rawBody;
 
-    const client = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
+    const client = getStreamServer();
     if (!client.verifyWebhook(bodyString, signature)) {
       return res.status(401).json({ message: "Invalid signature" });
     }

--- a/apps/backend/src/services/chat.service.ts
+++ b/apps/backend/src/services/chat.service.ts
@@ -1,5 +1,5 @@
 // src/services/chat.service.ts
-import { ChannelData, StreamChat } from "stream-chat";
+import { ChannelData } from "stream-chat";
 import dayjs from "dayjs";
 import crypto from "node:crypto";
 
@@ -8,16 +8,9 @@ import { AppointmentDocument } from "../models/appointment";
 import { UserProfileService } from "./user-profile.service";
 import { UserService } from "./user.service";
 import { prisma } from "src/config/prisma";
+import { getStreamServer } from "src/config/stream-client";
 
-const STREAM_KEY = process.env.STREAM_API_KEY!;
-const STREAM_SECRET = process.env.STREAM_API_SECRET!;
 const SYSTEM_USER_ID = "system-yosemite";
-
-if (!STREAM_KEY || !STREAM_SECRET) {
-  throw new Error("Stream Chat credentials missing in env");
-}
-
-const streamServer = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
 
 // Appointment chat window
 const PRE_WINDOW_MINUTES = 60 * 24;
@@ -222,13 +215,13 @@ export const ChatService = {
     if (!userId) throw new ChatServiceError("userId is required");
 
     return {
-      token: streamServer.createToken(userId),
+      token: getStreamServer().createToken(userId),
       expiresAt: Date.now() + 24 * 60 * 60 * 1000,
     };
   },
 
   async initSystemUserOnce() {
-    await streamServer.upsertUser({
+    await getStreamServer().upsertUser({
       id: SYSTEM_USER_ID,
       name: "Yosemite System",
       role: "admin",
@@ -263,7 +256,7 @@ export const ChatService = {
       throw new ChatServiceError("Parent not found in appointment", 404);
     }
 
-    await streamServer.upsertUser({
+    await getStreamServer().upsertUser({
       id: parentId,
       name: companion?.parent?.name || "Pet Owner",
       role: "user",
@@ -272,7 +265,7 @@ export const ChatService = {
     const lead = appointment.lead as { id?: string; name?: string } | null;
     const vetId = lead?.id ?? null;
     if (vetId) {
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         id: vetId,
         name: lead?.name || "Vet",
         role: "user",
@@ -285,7 +278,7 @@ export const ChatService = {
     const members = [parentId];
     if (vetId) members.push(vetId);
 
-    await streamServer.upsertUser({
+    await getStreamServer().upsertUser({
       id: SYSTEM_USER_ID,
       name: "Yosemite System",
       role: "admin",
@@ -309,7 +302,9 @@ export const ChatService = {
       members,
     };
 
-    await streamServer.channel("messaging", channelId, channelData).create();
+    await getStreamServer()
+      .channel("messaging", channelId, channelData)
+      .create();
 
     const session = await prisma.chatSession.create({
       data: {
@@ -364,7 +359,7 @@ export const ChatService = {
       );
       const user = await UserService.getById(userId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         name: user?.firstName + " " + user?.lastName || "User",
         id: userId,
         image:
@@ -384,7 +379,9 @@ export const ChatService = {
       organisationIds: [organisationId],
     };
 
-    await streamServer.channel("team", channelId, directChannelData).create();
+    await getStreamServer()
+      .channel("team", channelId, directChannelData)
+      .create();
 
     const session = await prisma.chatSession.create({
       data: {
@@ -431,7 +428,7 @@ export const ChatService = {
       );
       const user = await UserService.getById(userId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         name: user?.firstName + " " + user?.lastName || "User",
         id: userId,
         image:
@@ -451,7 +448,7 @@ export const ChatService = {
       organisationIds: [organisationId],
     };
 
-    await streamServer.channel("team", channelId, channelData).create();
+    await getStreamServer().channel("team", channelId, channelData).create();
 
     const session = await prisma.chatSession.create({
       data: {
@@ -513,7 +510,7 @@ export const ChatService = {
 
     assertCanCloseSession(session, actorUserId);
 
-    const channel = streamServer.channel(
+    const channel = getStreamServer().channel(
       getStreamChannelType(session.type),
       session.channelId,
     );
@@ -563,7 +560,7 @@ export const ChatService = {
       );
       const user = await UserService.getById(userId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         name: user?.firstName + " " + user?.lastName || "User",
         id: userId,
         image:
@@ -578,7 +575,7 @@ export const ChatService = {
       data: { members: updatedMembers },
     });
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
     await channel.addMembers(newMembers);
 
     return toChatSessionDocument(updated);
@@ -614,7 +611,7 @@ export const ChatService = {
       data: { members: nextMembers },
     });
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
     await channel.removeMembers(memberIds);
 
     return toChatSessionDocument(updated);
@@ -645,7 +642,7 @@ export const ChatService = {
       },
     });
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
 
     const data: YosemiteChannelResponse = {
       name: updates.title,
@@ -664,7 +661,7 @@ export const ChatService = {
 
     assertGroupAdminPrisma(session, actorUserId);
 
-    const channel = streamServer.channel("team", session.channelId);
+    const channel = getStreamServer().channel("team", session.channelId);
 
     try {
       await channel.delete();

--- a/apps/backend/src/services/networkChat.service.ts
+++ b/apps/backend/src/services/networkChat.service.ts
@@ -1,20 +1,12 @@
 // src/services/networkChat.service.ts
-import { ChannelData, StreamChat } from "stream-chat";
+import { ChannelData } from "stream-chat";
 import crypto from "node:crypto";
 
 import { ChatServiceError } from "./chat.service";
 import { UserProfileService } from "./user-profile.service";
 import { UserService } from "./user.service";
 import { prisma } from "src/config/prisma";
-
-const STREAM_KEY = process.env.STREAM_API_KEY!;
-const STREAM_SECRET = process.env.STREAM_API_SECRET!;
-
-if (!STREAM_KEY || !STREAM_SECRET) {
-  throw new Error("Stream Chat credentials missing in env");
-}
-
-const streamServer = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
+import { getStreamServer } from "src/config/stream-client";
 
 const MAX_COLLEAGUE_RESULTS = 25;
 
@@ -263,7 +255,7 @@ export const NetworkChatService = {
       );
       const user = await UserService.getById(userId);
 
-      await streamServer.upsertUser({
+      await getStreamServer().upsertUser({
         name: user?.firstName + " " + user?.lastName || "User",
         id: userId,
         image:
@@ -285,7 +277,7 @@ export const NetworkChatService = {
       organisationIds: [requesterOrgId, otherOrgId],
     };
 
-    await streamServer.channel("team", channelId, channelData).create();
+    await getStreamServer().channel("team", channelId, channelData).create();
 
     const session = await prisma.chatSession.create({
       data: {

--- a/apps/backend/src/services/sharedChatEntity.service.ts
+++ b/apps/backend/src/services/sharedChatEntity.service.ts
@@ -1,18 +1,9 @@
 // src/services/sharedChatEntity.service.ts
-import { StreamChat } from "stream-chat";
 import { Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
+import { getStreamServer } from "src/config/stream-client";
 import { ChatServiceError } from "src/services/chat.service";
 import logger from "src/utils/logger";
-
-const STREAM_KEY = process.env.STREAM_API_KEY!;
-const STREAM_SECRET = process.env.STREAM_API_SECRET!;
-
-if (!STREAM_KEY || !STREAM_SECRET) {
-  throw new Error("Stream Chat credentials missing in env");
-}
-
-const streamServer = StreamChat.getInstance(STREAM_KEY, STREAM_SECRET);
 
 // Group channels were created as Stream "team" channels; appointment and direct
 // channels as "messaging" (see chat.service.ts channel creation).
@@ -191,7 +182,7 @@ export const SharedChatEntityService = {
       appointmentId: session.appointmentId,
     });
 
-    const channel = streamServer.channel(
+    const channel = getStreamServer().channel(
       channelTypeForSession(session.type),
       channelId,
     );
@@ -257,7 +248,7 @@ export const SharedChatEntityService = {
 
     if (record.messageId) {
       try {
-        await streamServer.deleteMessage(record.messageId, true);
+        await getStreamServer().deleteMessage(record.messageId, true);
       } catch (err) {
         logger.warn("Failed to delete Stream message for revoked share", err);
       }

--- a/apps/backend/test/config/stream-client-laziness.test.ts
+++ b/apps/backend/test/config/stream-client-laziness.test.ts
@@ -1,0 +1,91 @@
+import fs from "node:fs";
+import path from "node:path";
+import { getStreamServer } from "src/config/stream-client";
+
+const STREAM_MODULES = [
+  "src/services/chat.service",
+  "src/services/networkChat.service",
+  "src/services/sharedChatEntity.service",
+] as const;
+
+const REQUIRED_EXAMPLE_KEYS = [
+  "DATABASE_URL",
+  "DIRECT_URL",
+  "REDIS_HOST",
+  "REDIS_PORT",
+  "REDIS_PASSWORD",
+  "STREAM_API_KEY",
+  "STREAM_API_SECRET",
+] as const;
+
+describe("optional Stream configuration", () => {
+  const savedKey = process.env.STREAM_API_KEY;
+  const savedSecret = process.env.STREAM_API_SECRET;
+
+  beforeEach(() => {
+    jest.resetModules();
+    delete process.env.STREAM_API_KEY;
+    delete process.env.STREAM_API_SECRET;
+  });
+
+  afterAll(() => {
+    if (savedKey === undefined) delete process.env.STREAM_API_KEY;
+    else process.env.STREAM_API_KEY = savedKey;
+    if (savedSecret === undefined) delete process.env.STREAM_API_SECRET;
+    else process.env.STREAM_API_SECRET = savedSecret;
+  });
+
+  it.each(STREAM_MODULES)(
+    "loads %s without Stream credentials",
+    (modulePath) => {
+      expect(() => {
+        jest.isolateModules(() => require(modulePath));
+      }).not.toThrow();
+    },
+  );
+
+  it("fails only when Stream functionality is invoked without credentials", () => {
+    expect(() => getStreamServer()).toThrow(
+      "Stream Chat credentials missing in env",
+    );
+  });
+
+  it("treats the blank values from the example file as unconfigured", () => {
+    process.env.STREAM_API_KEY = "";
+    process.env.STREAM_API_SECRET = "";
+    expect(() => getStreamServer()).toThrow(
+      "Stream Chat credentials missing in env",
+    );
+  });
+
+  it.each([
+    ["ordinary fixture key", undefined],
+    [undefined, "ordinary fixture secret"],
+  ])("rejects incomplete Stream credentials", (key, secret) => {
+    if (key === undefined) delete process.env.STREAM_API_KEY;
+    else process.env.STREAM_API_KEY = key;
+    if (secret === undefined) delete process.env.STREAM_API_SECRET;
+    else process.env.STREAM_API_SECRET = secret;
+
+    expect(() => getStreamServer()).toThrow(
+      "Stream Chat credentials missing in env",
+    );
+  });
+
+  it("creates a client once Stream credentials are configured", () => {
+    process.env.STREAM_API_KEY = "ordinary fixture key";
+    process.env.STREAM_API_SECRET = "ordinary fixture secret";
+    expect(getStreamServer()).toBeDefined();
+  });
+});
+
+it("documents every service required for local backend startup", () => {
+  const example = fs.readFileSync(
+    path.resolve(__dirname, "../../.env.example"),
+    "utf8",
+  );
+
+  for (const key of REQUIRED_EXAMPLE_KEYS) {
+    expect(example).toMatch(new RegExp(`^(?:# )?${key}=`, "m"));
+  }
+});


### PR DESCRIPTION
<!--
We, the rest of the Yosemite Crew community, thank you for your
contribution!
To help the rest of the community review your change, please follow the instructions in the template.
-->

<!-- PULL REQUEST TEMPLATE -->
<!-- (Update "[ ]" to "[x]" to check a box) -->

## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The checked-in backend environment example omits the application database, Redis, and Stream server variables used by the documented local workflow. Importing chat services also throws immediately when optional Stream credentials are absent, preventing the API module from loading before any chat operation is requested.

## What is the new behavior?

- Documents the required PostgreSQL and Redis variables and the optional Stream pair in the backend example.
- Documents separate application and SuperTokens databases.
- Resolves the Stream server client only when a chat or webhook operation needs it, so non-chat local API work can boot without Stream credentials.
- Adds regression coverage for import-time behavior, incomplete configuration, successful client creation, and the environment-example contract.

## Related Issue(s)

Fixes #2749

<!-- If this PR contains a breaking change, please describe the impact for existing applications below. -->

<!--
BREAKING CHANGES:


[Describe the impact of the changes here.]

-->
