### PR TITLE
fix(backend): normalize chat profile display names

### DIFF
--- a/apps/backend/src/services/chat.service.ts
+++ b/apps/backend/src/services/chat.service.ts
@@ -2,6 +2,7 @@
 import { ChannelData } from "stream-chat";
 import dayjs from "dayjs";
 import crypto from "node:crypto";
+import { z } from "zod";
 
 import { ChatSessionDocument, ChatSessionType } from "../models/chatSession";
 import { AppointmentDocument } from "../models/appointment";
@@ -42,6 +43,11 @@ type YosemiteChannelResponse = ChannelData & {
   name?: string;
   isPrivate?: boolean;
 };
+
+export const chatUserDisplayName = (
+  user?: { firstName?: string | null; lastName?: string | null } | null,
+) =>
+  [user?.firstName, user?.lastName].filter(Boolean).join(" ").trim() || "User";
 
 export class ChatServiceError extends Error {
   constructor(
@@ -360,7 +366,7 @@ export const ChatService = {
       const user = await UserService.getById(userId);
 
       await getStreamServer().upsertUser({
-        name: user?.firstName + " " + user?.lastName || "User",
+        name: chatUserDisplayName(user),
         id: userId,
         image:
           userProfile?.profile.personalDetails?.profilePictureUrl || undefined,
@@ -429,7 +435,7 @@ export const ChatService = {
       const user = await UserService.getById(userId);
 
       await getStreamServer().upsertUser({
-        name: user?.firstName + " " + user?.lastName || "User",
+        name: chatUserDisplayName(user),
         id: userId,
         image:
           userProfile?.profile.personalDetails?.profilePictureUrl || undefined,
@@ -561,7 +567,7 @@ export const ChatService = {
       const user = await UserService.getById(userId);
 
       await getStreamServer().upsertUser({
-        name: user?.firstName + " " + user?.lastName || "User",
+        name: chatUserDisplayName(user),
         id: userId,
         image:
           userProfile?.profile.personalDetails?.profilePictureUrl || undefined,
@@ -654,8 +660,14 @@ export const ChatService = {
   },
 
   async deleteGroup(sessionId: string, actorUserId: string) {
+    const parsedSessionId = z.uuid().safeParse(sessionId);
+    if (!parsedSessionId.success) {
+      throw new ChatServiceError("sessionId is required");
+    }
+    const safeSessionId = String(parsedSessionId.data);
+
     const session = await prisma.chatSession.findFirst({
-      where: { id: sessionId },
+      where: { id: safeSessionId },
     });
     if (!session) return;
 
@@ -669,6 +681,8 @@ export const ChatService = {
       // Stream failure should not block DB cleanup
     }
 
-    await prisma.chatSession.deleteMany({ where: { id: sessionId } });
+    await prisma.chatSession.deleteMany({
+      where: { id: safeSessionId },
+    });
   },
 };

--- a/apps/backend/src/services/networkChat.service.ts
+++ b/apps/backend/src/services/networkChat.service.ts
@@ -2,7 +2,7 @@
 import { ChannelData } from "stream-chat";
 import crypto from "node:crypto";
 
-import { ChatServiceError } from "./chat.service";
+import { ChatServiceError, chatUserDisplayName } from "./chat.service";
 import { UserProfileService } from "./user-profile.service";
 import { UserService } from "./user.service";
 import { prisma } from "src/config/prisma";
@@ -256,7 +256,7 @@ export const NetworkChatService = {
       const user = await UserService.getById(userId);
 
       await getStreamServer().upsertUser({
-        name: user?.firstName + " " + user?.lastName || "User",
+        name: chatUserDisplayName(user),
         id: userId,
         image:
           userProfile?.profile.personalDetails?.profilePictureUrl || undefined,

--- a/apps/backend/test/services/chat.service.coverage.test.ts
+++ b/apps/backend/test/services/chat.service.coverage.test.ts
@@ -268,6 +268,25 @@ describe("ChatService.createOrgDirectChat", () => {
     );
     expect(res).toEqual({ ...created, _id: created.id });
   });
+
+  it("uses safe Stream names when direct-chat profiles are incomplete", async () => {
+    mockedPrisma.chatSession.findFirst.mockResolvedValue(null);
+    mockedPrisma.chatSession.create.mockResolvedValue({ id: "s-new" });
+    mockedUserService.getById
+      .mockResolvedValueOnce({ firstName: " ", lastName: "" })
+      .mockResolvedValueOnce({ firstName: "Jane" });
+
+    await ChatService.createOrgDirectChat("org1", "userB", "userA");
+
+    expect(mockUpsertUser).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: "userA", name: "User" }),
+    );
+    expect(mockUpsertUser).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ id: "userB", name: "Jane" }),
+    );
+  });
 });
 
 /* ----------------------------- createOrgGroupChat -------------------------- */
@@ -600,8 +619,9 @@ describe("ChatService.updateGroup", () => {
 /* -------------------------------- deleteGroup ------------------------------ */
 
 describe("ChatService.deleteGroup", () => {
+  const sessionId = "9b2bdf69-b118-4324-8960-27a910edbcea";
   const baseGroup = {
-    id: "s1",
+    id: sessionId,
     type: "ORG_GROUP",
     createdBy: "owner",
     status: "ACTIVE",
@@ -610,15 +630,31 @@ describe("ChatService.deleteGroup", () => {
     channelId: "ch1",
   };
 
+  it("rejects non-string session ids before querying", async () => {
+    await expect(
+      ChatService.deleteGroup({ $ne: "s1" } as unknown as string, "owner"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+
+    expect(mockedPrisma.chatSession.findFirst).not.toHaveBeenCalled();
+  });
+
+  it("rejects malformed session ids before querying", async () => {
+    await expect(
+      ChatService.deleteGroup("not-a-uuid", "owner"),
+    ).rejects.toMatchObject({ statusCode: 400 });
+
+    expect(mockedPrisma.chatSession.findFirst).not.toHaveBeenCalled();
+  });
+
   it("deletes the group", async () => {
     mockedPrisma.chatSession.findFirst.mockResolvedValue(baseGroup);
     mockedPrisma.chatSession.deleteMany.mockResolvedValue({ count: 1 });
 
-    await ChatService.deleteGroup("s1", "owner");
+    await ChatService.deleteGroup(sessionId, "owner");
 
     expect(mockDelete).toHaveBeenCalled();
     expect(mockedPrisma.chatSession.deleteMany).toHaveBeenCalledWith({
-      where: { id: "s1" },
+      where: { id: sessionId },
     });
   });
 
@@ -627,7 +663,7 @@ describe("ChatService.deleteGroup", () => {
     mockDelete.mockRejectedValue(new Error("stream down"));
     mockedPrisma.chatSession.deleteMany.mockResolvedValue({ count: 1 });
 
-    await ChatService.deleteGroup("s1", "owner");
+    await ChatService.deleteGroup(sessionId, "owner");
 
     expect(mockedPrisma.chatSession.deleteMany).toHaveBeenCalled();
   });
@@ -636,7 +672,7 @@ describe("ChatService.deleteGroup", () => {
     mockedPrisma.chatSession.findFirst.mockResolvedValue(null);
 
     await expect(
-      ChatService.deleteGroup("s1", "owner"),
+      ChatService.deleteGroup(sessionId, "owner"),
     ).resolves.toBeUndefined();
     expect(mockDelete).not.toHaveBeenCalled();
   });

--- a/apps/backend/test/services/networkChat.service.test.ts
+++ b/apps/backend/test/services/networkChat.service.test.ts
@@ -378,6 +378,32 @@ describe("NetworkChatService.createNetworkDirectChat", () => {
     expect(result).toBe(created);
   });
 
+  it("uses safe Stream names when cross-org profiles are incomplete", async () => {
+    bothOrgsEnabled();
+    mockedPrisma.chatSession.findFirst.mockResolvedValue(null);
+    mockedUserProfile.mockResolvedValue({ profile: { personalDetails: {} } });
+    mockedUserService
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ lastName: "Doe" });
+    mockedPrisma.chatSession.create.mockResolvedValue({ id: "new" });
+
+    await NetworkChatService.createNetworkDirectChat({
+      requesterUserId: "userA",
+      requesterOrgId: "org1",
+      otherUserId: "userB",
+      otherOrgId: "org2",
+    });
+
+    expect(mockUpsertUser).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ id: "userA", name: "User" }),
+    );
+    expect(mockUpsertUser).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ id: "userB", name: "Doe" }),
+    );
+  });
+
   it("rejects with 400 when a user tries to chat with themselves", async () => {
     await expect(
       NetworkChatService.createNetworkDirectChat({


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Missing or partial user names are concatenated directly before Stream profile upserts, producing truthy values such as `undefined undefined`, `Jane undefined`, or `undefined Doe` instead of the intended fallback. The touched chat service also accepted a runtime session identifier without validating it before a Prisma delete lookup.

## What is the new behavior?

All four chat profile upserts share one formatter that joins only populated name parts, trims whitespace, and falls back to `User`. The group-delete service validates and casts its session identifier before querying. Regression tests cover same-clinic and cross-clinic name handling plus the rejected injection-shaped identifier input.

## Related Issue(s)

Fixes #3033
