### PR TITLE
fix(backend): prevent appointment pagination gaps

### DIFF
--- a/apps/backend/src/controllers/web/developer-data.controller.ts
+++ b/apps/backend/src/controllers/web/developer-data.controller.ts
@@ -21,8 +21,9 @@ import {
 import {
   clampPageSize,
   DeveloperDataService,
+  parseAppointmentCursor,
+  UnknownAppointmentCursorError,
 } from "../../services/developer-data.service";
-import { parseUuidCursor } from "../../services/shared/pagination";
 import { DeveloperUsageService } from "../../services/developer-usage.service";
 
 type ErrorCode =
@@ -134,7 +135,7 @@ export const DeveloperDataController = {
      */
     const rawCursor =
       typeof req.query.cursor === "string" ? req.query.cursor : "";
-    const cursor = parseUuidCursor(req.query.cursor);
+    const cursor = parseAppointmentCursor(req.query.cursor);
     if (cursor === null) {
       // Logged newline-stripped: the value is caller-controlled and a raw CR/LF
       // in it would forge a second log line.
@@ -164,6 +165,15 @@ export const DeveloperDataController = {
         pagination: { limit, nextCursor: page.nextCursor },
       });
     } catch (err) {
+      if (err instanceof UnknownAppointmentCursorError) {
+        fail(
+          res,
+          400,
+          "invalid_request",
+          "Unknown or expired cursor. Use pagination.nextCursor from the previous response.",
+        );
+        return;
+      }
       logger.error("DeveloperDataController.listAppointments failed", err);
       fail(res, 500, "internal_error", "Internal server error");
     }

--- a/apps/backend/src/services/developer-data.service.ts
+++ b/apps/backend/src/services/developer-data.service.ts
@@ -12,6 +12,9 @@ import type { AppointmentStatus, Prisma } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import {
   clampPageSize as clampToBounds,
+  encodeKeysetCursor,
+  parseKeysetCursor,
+  parseUuidCursor,
   splitPage,
 } from "src/services/shared/pagination";
 
@@ -53,11 +56,39 @@ export interface OrganizationSummary {
 export interface AppointmentQuery {
   organisationId: string;
   limit: number;
-  cursor?: string;
+  cursor?: AppointmentCursor;
   from?: Date;
   to?: Date;
   status?: AppointmentStatus;
 }
+
+export type AppointmentCursor =
+  { appointmentDate: Date; id: string } | { legacyId: string };
+
+export class UnknownAppointmentCursorError extends Error {}
+
+export const encodeAppointmentCursor = ({
+  appointmentDate,
+  id,
+}: Extract<AppointmentCursor, { appointmentDate: Date }>): string =>
+  encodeKeysetCursor({ createdAt: appointmentDate, id });
+
+export const parseAppointmentCursor = (
+  raw: unknown,
+): AppointmentCursor | undefined | null => {
+  const keyset = parseKeysetCursor(raw);
+  if (keyset) {
+    return { appointmentDate: keyset.createdAt, id: keyset.id };
+  }
+  if (keyset === undefined) {
+    return undefined;
+  }
+  const legacyId = parseUuidCursor(raw);
+  if (typeof legacyId !== "string") {
+    return legacyId;
+  }
+  return { legacyId };
+};
 
 export interface Page<T> {
   items: T[];
@@ -141,10 +172,9 @@ export const DeveloperDataService = {
   },
 
   /*
-   * Keyset pagination via Prisma's `cursor`, ordered by `(appointmentDate, id)`.
-   * The id tiebreak is not decoration: several appointments share a date, and
-   * without it the order is unstable and a page boundary can drop or repeat a
-   * row. `skip: 1` steps past the cursor row itself.
+   * Keyset pagination ordered by `(appointmentDate, id)`. The id tiebreak is
+   * not decoration: several appointments share a date, and without it the
+   * order is unstable and a page boundary can drop or repeat a row.
    */
   async listAppointments(query: AppointmentQuery): Promise<Page<unknown>> {
     const where: Prisma.AppointmentWhereInput = {
@@ -162,15 +192,43 @@ export const DeveloperDataService = {
       where.status = query.status;
     }
 
+    let cursor = query.cursor;
+    if (cursor && "legacyId" in cursor) {
+      const legacyRow = await prisma.appointment.findFirst({
+        where: {
+          id: cursor.legacyId,
+          organisationId: query.organisationId,
+        },
+        select: { id: true, appointmentDate: true },
+      });
+      if (!legacyRow) {
+        throw new UnknownAppointmentCursorError();
+      }
+      cursor = legacyRow;
+    }
+
+    if (cursor) {
+      where.OR = [
+        { appointmentDate: { gt: cursor.appointmentDate } },
+        {
+          appointmentDate: cursor.appointmentDate,
+          id: { gt: cursor.id },
+        },
+      ];
+    }
+
     const rows = await prisma.appointment.findMany({
       where,
       select: APPOINTMENT_FIELDS,
       orderBy: [{ appointmentDate: "asc" }, { id: "asc" }],
       take: query.limit + 1,
-      ...(query.cursor ? { cursor: { id: query.cursor }, skip: 1 } : {}),
     });
 
-    const { items, nextCursor } = splitPage(rows, query.limit);
+    const { items, nextCursor } = splitPage(
+      rows,
+      query.limit,
+      encodeAppointmentCursor,
+    );
 
     return { items, nextCursor };
   },

--- a/apps/backend/test/controllers/developer-data.controller.test.ts
+++ b/apps/backend/test/controllers/developer-data.controller.test.ts
@@ -6,6 +6,15 @@ const getAppointment = jest.fn();
 jest.mock("src/services/developer-data.service", () => ({
   clampPageSize: jest.requireActual("src/services/developer-data.service")
     .clampPageSize,
+  encodeAppointmentCursor: jest.requireActual(
+    "src/services/developer-data.service",
+  ).encodeAppointmentCursor,
+  parseAppointmentCursor: jest.requireActual(
+    "src/services/developer-data.service",
+  ).parseAppointmentCursor,
+  UnknownAppointmentCursorError: jest.requireActual(
+    "src/services/developer-data.service",
+  ).UnknownAppointmentCursorError,
   DeveloperDataService: { listOrganizations, listAppointments, getAppointment },
 }));
 
@@ -22,6 +31,10 @@ jest.mock("src/utils/logger", () => ({
 }));
 
 import { DeveloperDataController } from "src/controllers/web/developer-data.controller";
+import {
+  encodeAppointmentCursor,
+  UnknownAppointmentCursorError,
+} from "src/services/developer-data.service";
 
 const buildRes = () => {
   const res = {} as Response & { body?: unknown; code?: number };
@@ -157,7 +170,7 @@ describe("listAppointments", () => {
     expect(listAppointments).not.toHaveBeenCalled();
   });
 
-  it("accepts a well-formed cursor", async () => {
+  it("accepts an in-flight UUID cursor", async () => {
     listAppointments.mockResolvedValue({ items: [], nextCursor: null });
     const cursor = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
     await DeveloperDataController.listAppointments(
@@ -165,8 +178,42 @@ describe("listAppointments", () => {
       buildRes(),
     );
     expect(listAppointments).toHaveBeenCalledWith(
-      expect.objectContaining({ cursor }),
+      expect.objectContaining({ cursor: { legacyId: cursor } }),
     );
+  });
+
+  it("accepts the opaque appointment keyset cursor", async () => {
+    listAppointments.mockResolvedValue({ items: [], nextCursor: null });
+    const cursor = encodeAppointmentCursor({
+      appointmentDate: new Date("2026-09-11T09:00:00.000Z"),
+      id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+    });
+    await DeveloperDataController.listAppointments(
+      buildReq({ query: { cursor } } as never),
+      buildRes(),
+    );
+    expect(listAppointments).toHaveBeenCalledWith(
+      expect.objectContaining({
+        cursor: {
+          appointmentDate: new Date("2026-09-11T09:00:00.000Z"),
+          id: "3f2504e0-4f89-41d3-9a0c-0305e82c3301",
+        },
+      }),
+    );
+  });
+
+  it("400s when a legacy cursor no longer names an appointment in the practice", async () => {
+    listAppointments.mockRejectedValue(new UnknownAppointmentCursorError());
+    const res = buildRes();
+    await DeveloperDataController.listAppointments(
+      buildReq({
+        query: { cursor: "3f2504e0-4f89-41d3-9a0c-0305e82c3301" },
+      } as never),
+      res,
+    );
+    expect(res.code).toBe(400);
+    expect(res.body).toMatchObject({ code: "invalid_request" });
+    expect(errorLog).not.toHaveBeenCalled();
   });
 
   /*

--- a/apps/backend/test/services/developer-data.service.test.ts
+++ b/apps/backend/test/services/developer-data.service.test.ts
@@ -24,10 +24,17 @@ const store: {
 const matches = (row: Row, where: Row | undefined): boolean => {
   if (!where) return true;
   return Object.entries(where).every(([field, condition]) => {
+    if (field === "OR") {
+      return (condition as Row[]).some((candidate) => matches(row, candidate));
+    }
     const value = row[field];
+    if (condition instanceof Date) {
+      return value instanceof Date && value.getTime() === condition.getTime();
+    }
     if (condition !== null && typeof condition === "object") {
       const c = condition as Record<string, unknown>;
       if ("in" in c) return (c.in as unknown[]).includes(value);
+      if ("gt" in c && (value as never) <= (c.gt as never)) return false;
       if ("gte" in c && (value as Date) < (c.gte as Date)) return false;
       if ("lte" in c && (value as Date) > (c.lte as Date)) return false;
       return true;
@@ -102,11 +109,24 @@ import {
   DeveloperDataService,
   MAX_PAGE_SIZE,
   normaliseOrganisationReference,
+  parseAppointmentCursor,
+  UnknownAppointmentCursorError,
 } from "src/services/developer-data.service";
 
 const ORG_A = "org-a";
 const ORG_B = "org-b";
 const USER = "user-1";
+const APPOINTMENT_IDS = [
+  "00000000-0000-4000-8000-000000000001",
+  "00000000-0000-4000-8000-000000000002",
+  "00000000-0000-4000-8000-000000000003",
+];
+
+const useUuidAppointmentIds = () => {
+  store.appointment.slice(0, 3).forEach((appointment, index) => {
+    appointment.id = APPOINTMENT_IDS[index];
+  });
+};
 
 const appointmentAt = (id: string, organisationId: string, day: number) => ({
   id,
@@ -223,23 +243,97 @@ describe("listAppointments", () => {
   });
 
   it("paginates without dropping or repeating a row across the boundary", async () => {
+    useUuidAppointmentIds();
     const first = await DeveloperDataService.listAppointments({
       organisationId: ORG_A,
       limit: 2,
     });
     expect((first.items as { id: string }[]).map((i) => i.id)).toEqual([
-      "a1",
-      "a2",
+      APPOINTMENT_IDS[0],
+      APPOINTMENT_IDS[1],
     ]);
-    expect(first.nextCursor).toBe("a2");
+    const cursor = parseAppointmentCursor(first.nextCursor);
+    expect(cursor).toEqual({
+      id: APPOINTMENT_IDS[1],
+      appointmentDate: new Date(Date.UTC(2026, 8, 2)),
+    });
+    if (!cursor) throw new Error("Expected a valid appointment cursor");
 
     const second = await DeveloperDataService.listAppointments({
       organisationId: ORG_A,
       limit: 2,
-      cursor: first.nextCursor ?? undefined,
+      cursor,
     });
-    expect((second.items as { id: string }[]).map((i) => i.id)).toEqual(["a3"]);
+    expect((second.items as { id: string }[]).map((i) => i.id)).toEqual([
+      APPOINTMENT_IDS[2],
+    ]);
     expect(second.nextCursor).toBeNull();
+  });
+
+  it("does not drop the next row when the cursor appointment leaves the status filter", async () => {
+    useUuidAppointmentIds();
+    const first = await DeveloperDataService.listAppointments({
+      organisationId: ORG_A,
+      limit: 2,
+      status: "UPCOMING" as never,
+    });
+    store.appointment[1].status = "CANCELLED";
+    const cursor = parseAppointmentCursor(first.nextCursor);
+    if (!cursor) throw new Error("Expected a valid appointment cursor");
+
+    const second = await DeveloperDataService.listAppointments({
+      organisationId: ORG_A,
+      limit: 2,
+      status: "UPCOMING" as never,
+      cursor,
+    });
+
+    expect((second.items as { id: string }[]).map((item) => item.id)).toEqual([
+      APPOINTMENT_IDS[2],
+    ]);
+  });
+
+  it("uses id as the exclusive tiebreak when appointment dates match", async () => {
+    store.appointment[2].appointmentDate = store.appointment[1].appointmentDate;
+    const cursor = {
+      appointmentDate: store.appointment[1].appointmentDate as Date,
+      id: "a2",
+    };
+
+    const page = await DeveloperDataService.listAppointments({
+      organisationId: ORG_A,
+      limit: 2,
+      cursor,
+    });
+
+    expect((page.items as { id: string }[]).map((item) => item.id)).toEqual([
+      "a3",
+    ]);
+  });
+
+  it("accepts an in-flight UUID cursor through the scoped compatibility lookup", async () => {
+    const legacyId = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+    store.appointment[1].id = legacyId;
+
+    const page = await DeveloperDataService.listAppointments({
+      organisationId: ORG_A,
+      limit: 2,
+      cursor: { legacyId },
+    });
+
+    expect((page.items as { id: string }[]).map((item) => item.id)).toEqual([
+      "a3",
+    ]);
+  });
+
+  it("rejects a legacy cursor that belongs to another practice", async () => {
+    await expect(
+      DeveloperDataService.listAppointments({
+        organisationId: ORG_A,
+        limit: 2,
+        cursor: { legacyId: "b1" },
+      }),
+    ).rejects.toBeInstanceOf(UnknownAppointmentCursorError);
   });
 
   it("filters by date window", async () => {


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Appointment pagination uses Prisma's row cursor with `skip: 1`. If the cursor appointment changes status or date between requests and no longer matches the active filters, Prisma resolves the cursor before filtering and the skip removes the first valid row from the next page.

## What is the new behavior?

- Encodes the appointment date and id in the opaque next-page cursor and applies an exclusive `(appointmentDate, id)` boundary inside the active filters.
- Accepts in-flight UUID cursors through a practice-scoped compatibility lookup.
- Returns a clear 400 response for unknown or expired legacy cursors without turning unrelated database failures into client errors.
- Covers filter mutation, tied dates, cursor compatibility, tenant scoping, and controller behavior.

Validation:
- Reproduced the dropped row against PostgreSQL 16 before the fix and verified every remaining row is returned after the fix.
- Focused Jest: 41 tests passed with 97.6% statement and 90.41% branch coverage across the changed production files.
- Full backend Jest: 491 suites and 11,679 tests passed; the runner reported a lingering async handle after its final summary.
- Backend and monorepo lint/type-check gates passed; backend build passed.
- Six targeted mutations each failed their intended regression test.
- Aikido scan found no issues in the four changed files; staged gitleaks and secretlint checks passed.

## Related Issue(s)

Fixes #2722
