### PR TITLE
fix(backend): suppress terminal companion history cursor

### DIFF
--- a/apps/backend/src/services/companion-history.service.ts
+++ b/apps/backend/src/services/companion-history.service.ts
@@ -781,7 +781,7 @@ export const CompanionHistoryService = {
 
     const paged = filtered.slice(0, limit);
     const nextCursor =
-      paged.length === limit ? buildCursor(paged.at(-1)!) : null;
+      filtered.length > limit ? buildCursor(paged.at(-1)!) : null;
 
     const countsByType = paged.reduce(
       (acc, entry) => {

--- a/apps/backend/test/services/companion-history.service.test.ts
+++ b/apps/backend/test/services/companion-history.service.test.ts
@@ -123,6 +123,41 @@ describe("CompanionHistoryService", () => {
     expect(secondPage.entries[0].link.id).toBe("apt-2");
   });
 
+  it("does not return a cursor when the final page exactly matches the limit", async () => {
+    (TaskService.listForCompanion as jest.Mock).mockResolvedValue([
+      {
+        _id: "task-1",
+        organisationId,
+        name: "First task",
+        category: "CARE",
+        audience: "EMPLOYEE_TASK",
+        dueAt: new Date("2024-01-02T09:00:00.000Z"),
+        status: "PENDING",
+        createdAt: new Date("2024-01-02T09:00:00.000Z"),
+      },
+      {
+        _id: "task-2",
+        organisationId,
+        name: "Second task",
+        category: "CARE",
+        audience: "EMPLOYEE_TASK",
+        dueAt: new Date("2024-01-01T09:00:00.000Z"),
+        status: "PENDING",
+        createdAt: new Date("2024-01-01T09:00:00.000Z"),
+      },
+    ]);
+
+    const result = await CompanionHistoryService.listForCompanion({
+      organisationId,
+      patientId: companionId,
+      limit: 2,
+      types: ["TASK"],
+    });
+
+    expect(result.entries).toHaveLength(2);
+    expect(result.nextCursor).toBeNull();
+  });
+
   it("filters by types", async () => {
     (
       AppointmentService.getAppointmentsForCompanionByOrganisation as jest.Mock


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Companion history returns a continuation cursor whenever a page contains exactly the requested number of entries, even when no additional entry exists.

## What is the new behavior?

The service returns a cursor only when the filtered result contains an entry beyond the current page. A regression test covers an exact-limit terminal page.

Validation:

- Companion history service suite: 17 tests passed.
- Deliberate comparison mutation: the regression test failed as expected.
- Backend lint and type-check completed successfully.
- Repository pre-push lint and type-check completed successfully.

## Related Issue(s)

Fixes #3037
