### PR TITLE
fix(frontend): stop the sidebar flashing collapsed on hydration

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Sidebar.test.tsx
@@ -258,6 +258,23 @@ describe('Sidebar', () => {
     expect(window.localStorage.getItem('yc_sidebar_collapsed')).toBe('1');
   });
 
+  it('falls back to the viewport width when no preference is stored, and stays live on resize', () => {
+    setup({ pathname: '/dashboard' }); // no explicit `collapsed` -> nothing stored
+    Object.defineProperty(window, 'innerWidth', {
+      writable: true,
+      configurable: true,
+      value: 1440,
+    });
+
+    const { container } = render(<Sidebar />);
+    expect(container.querySelector('.sidebar-collapsed')).not.toBeInTheDocument();
+
+    Object.defineProperty(window, 'innerWidth', { writable: true, configurable: true, value: 500 });
+    fireEvent(window, new Event('resize'));
+
+    expect(container.querySelector('.sidebar-collapsed')).toBeInTheDocument();
+  });
+
   it('renders the collapsed icon rail when the stored preference is collapsed', () => {
     setup({ pathname: '/organization', collapsed: true });
 
@@ -367,5 +384,32 @@ describe('active-route focus ring stays distinct from the active-route colour', 
 
   it('gives .route-active:focus-visible its own outline colour', () => {
     expect(css).toMatch(/\.route-active:focus-visible\s*{\s*outline-color:\s*var\(--ink\);?\s*}/);
+  });
+});
+
+describe('sidebar collapse state does not read browser globals during the initial render', () => {
+  // jsdom can't reproduce a real server-to-client hydration pass (both the
+  // render and any effect run with full localStorage/window access in the
+  // test environment), so this is a source-text guard: the initial useState
+  // must be a plain `false` seeded from nothing but a literal, and the real
+  // preference (isSidebarCollapsedByDefault, which reads localStorage and
+  // window.innerWidth) must only be read inside a useEffect. Seeding the
+  // initial state from it directly means the client's first hydration render
+  // diverges from the server-rendered markup for any returning user with a
+  // stored "collapsed" preference or a <1280px viewport.
+  const source = readFileSync(join(process.cwd(), 'src/app/ui/layout/Sidebar/Sidebar.tsx'), 'utf8');
+
+  it('seeds prefersCollapsed with a literal false, not a browser read', () => {
+    expect(source).toMatch(/const \[prefersCollapsed, setPrefersCollapsed\] = useState\(false\);/);
+  });
+
+  it('reads the real preference only inside a post-mount effect', () => {
+    expect(source).toMatch(
+      /const update = \(\) => setPrefersCollapsed\(isSidebarCollapsedByDefault\(\)\);/
+    );
+  });
+
+  it('re-checks the preference on resize, not just once at mount', () => {
+    expect(source).toMatch(/globalThis\.window\?\.addEventListener\('resize', update\)/);
   });
 });

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { usePathname, useRouter } from 'next/navigation';
 import Image from 'next/image';
@@ -93,7 +93,22 @@ const Sidebar = () => {
   useLoadSpecialitiesForPrimaryOrg();
   const pathname = usePathname();
   const router = useRouter();
-  const [prefersCollapsed, setPrefersCollapsed] = useState(() => isSidebarCollapsedByDefault());
+  // Starts `false` during SSR and the first client render (matching
+  // useIsTabletRail below) - isSidebarCollapsedByDefault() reads
+  // localStorage/window.innerWidth, which aren't available on the server, so
+  // seeding the initial state from it directly caused the client's first
+  // hydration pass to diverge from the server-rendered markup for any
+  // returning user with a stored "collapsed" preference or a <1280px
+  // viewport. Corrected post-mount instead, same as the tablet check, and
+  // re-checked on resize so the viewport fallback in isSidebarCollapsedByDefault
+  // (used only while no explicit preference is stored) stays live.
+  const [prefersCollapsed, setPrefersCollapsed] = useState(false);
+  useEffect(() => {
+    const update = () => setPrefersCollapsed(isSidebarCollapsedByDefault());
+    update();
+    globalThis.window?.addEventListener('resize', update);
+    return () => globalThis.window?.removeEventListener('resize', update);
+  }, []);
   // Tablet is always the icon rail, so it overrides a stored desktop preference
   // (which would otherwise render the 224px sidebar after a desktop -> tablet resize).
   const isTabletRail = useIsTabletRail();


### PR DESCRIPTION
## Summary

- `prefersCollapsed` seeded its `useState` from `isSidebarCollapsedByDefault()`, which reads `localStorage` and `window.innerWidth` — neither available during SSR. The server always rendered expanded, but the client's first hydration render read the real value, so any returning user with a stored "collapsed" preference, or a `<1280px` viewport, saw the sidebar hydrate expanded then immediately snap to collapsed.
- Fixed by matching the exact pattern `useIsTabletRail` already uses one function below it in the same file: start `false` (matching SSR), correct post-mount in an effect, and re-check on `resize` so the viewport fallback (used only while no explicit preference is stored) stays live.
- Hit one `react-hooks/set-state-in-effect` lint requirement along the way: a bare "read once, setState once" effect isn't enough — the rule wants the setState paired with a real subscription. `useIsTabletRail` satisfies it via its `addEventListener('change', ...)`; this fix does the analogous thing with `addEventListener('resize', ...)`, which is also a genuine, real improvement (the viewport fallback now stays correct across a resize, not just at mount).

Found via a fresh react-doctor scan (`react-doctor/no-hydration-branch-on-browser-global`) — most of that scan's error-tier findings turned out to be false positives once read against the code (guarded portals, state setters the linter can't trace through custom hooks, etc.), this one wasn't.

## Test plan
- [x] New source-text regression tests: the initial `useState` is a literal `false`, and the real preference is only read inside a `useEffect`
- [x] New behavioral test: falls back to the viewport width when nothing is stored, and stays live on resize
- [x] Mutation-checked: reverting to the eager `useState(() => isSidebarCollapsedByDefault())` breaks all 4 new tests; removing just the resize listener (keeping the mount-time read) breaks 2 of them, confirming the resize test isn't redundant with the source-text check
- [x] All 17 pre-existing Sidebar tests still pass unchanged
- [x] `tsc --noEmit` and `eslint` clean, `check-hardcoded-colours.mjs`: 0 to migrate (no styling touched)