### PR TITLE
fix(backend): dedupe the two-spellings-per-breed vocabulary entries

### DIFF
--- a/apps/backend/src/scripts/dedupe-breed-codes.ts
+++ b/apps/backend/src/scripts/dedupe-breed-codes.ts
@@ -1,0 +1,189 @@
+/**
+ * Collapse the breed vocabulary's two-spellings-per-breed duplicates onto one code.
+ *
+ * `CodeEntry` holds the same breed under both separator conventions for 36
+ * breeds - `YBREED:CANINE:SHIH_TZU` and `YBREED:CANINE:SHIH-TZU` are two rows
+ * for one breed, and the seven already-coded companions in production are
+ * split across both. Anything that joins on `breedCode` literally - reporting,
+ * PIMS filters, IDEXX reference ranges, an export - silently misses whichever
+ * half of the population is coded the other way (#2450).
+ *
+ * Underscore wins. `buildBreedCode` in idexx-reference.service.ts, the only
+ * live writer of new breed codes, has always emitted underscores; keeping
+ * hyphen as canonical would leave that generator producing a "new" duplicate
+ * against it forever.
+ *
+ * A loser is DEACTIVATED, never deleted - the rest of the codebase already
+ * treats `active: false` as invisible (every vocabulary query filters on it,
+ * same as `backfill-breed-codes.ts`), so this reaches "one code per breed"
+ * without destroying the audit trail of where the row came from.
+ *
+ * Dry run by default. Pass --apply to write:
+ *
+ *   pnpm --filter backend exec tsx src/scripts/dedupe-breed-codes.ts
+ *   pnpm --filter backend exec tsx src/scripts/dedupe-breed-codes.ts --apply
+ */
+import { prisma } from "src/config/prisma";
+import { canonicalBreedCode } from "src/services/shared/breed-code";
+
+export interface DedupeGroup {
+  canonical: string;
+  winner: string;
+  losers: string[];
+}
+
+export interface UnresolvedGroup {
+  canonical: string;
+  codes: string[];
+  reason: string;
+}
+
+export interface DedupePlan {
+  groups: DedupeGroup[];
+  unresolved: UnresolvedGroup[];
+}
+
+/**
+ * Group every breed code by its canonical form and split each group into a
+ * winner - the one spelling that already equals its own canonical form - and
+ * the rest. A group where zero or more than one code already matches the
+ * canonical form is reported unresolved rather than guessed at: a wrong
+ * repoint is worse than a duplicate left in place.
+ */
+export const planDedupe = async (): Promise<DedupePlan> => {
+  const entries = await prisma.codeEntry.findMany({
+    where: { system: "YOSEMITECODE", type: "BREED" },
+    select: { code: true },
+  });
+
+  const byCanonical = new Map<string, string[]>();
+  for (const entry of entries) {
+    const canonical = canonicalBreedCode(entry.code);
+    if (!canonical) continue;
+    byCanonical.set(canonical, [
+      ...(byCanonical.get(canonical) ?? []),
+      entry.code,
+    ]);
+  }
+
+  const groups: DedupeGroup[] = [];
+  const unresolved: UnresolvedGroup[] = [];
+
+  for (const [canonical, codes] of byCanonical) {
+    if (codes.length < 2) continue;
+
+    const winners = codes.filter((code) => code === canonical);
+    if (winners.length !== 1) {
+      unresolved.push({
+        canonical,
+        codes,
+        reason:
+          winners.length === 0
+            ? "no code already matches the canonical form"
+            : "more than one code already matches the canonical form",
+      });
+      continue;
+    }
+
+    const winner = winners[0];
+    groups.push({
+      canonical,
+      winner,
+      losers: codes.filter((code) => code !== winner),
+    });
+  }
+
+  return { groups, unresolved };
+};
+
+export const main = async () => {
+  const apply = process.argv.includes("--apply");
+  const { groups, unresolved } = await planDedupe();
+
+  console.log(`${groups.length} duplicate breed pairs found`);
+  for (const group of groups) {
+    console.log(`  ${group.losers.join(", ")} -> ${group.winner}`);
+  }
+  if (unresolved.length > 0) {
+    console.log(`${unresolved.length} unresolved groups`);
+    for (const group of unresolved) {
+      console.log(
+        `  SKIP ${group.canonical} - ${group.reason}: ${group.codes.join(", ")}`,
+      );
+    }
+  }
+
+  if (!apply) {
+    console.log("\ndry run; pass --apply to write");
+    return;
+  }
+
+  let patientsRepointed = 0;
+  let mappingsRepointed = 0;
+  let mappingsDeduped = 0;
+  let entriesDeactivated = 0;
+
+  for (const group of groups) {
+    for (const loser of group.losers) {
+      const patientResult = await prisma.patient.updateMany({
+        where: { breedCode: loser },
+        data: { breedCode: group.winner },
+      });
+      patientsRepointed += patientResult.count;
+
+      const loserMappings = await prisma.codeMapping.findMany({
+        where: { sourceSystem: "YOSEMITECODE", sourceCode: loser },
+      });
+      for (const mapping of loserMappings) {
+        const existing = await prisma.codeMapping.findUnique({
+          where: {
+            sourceSystem_sourceCode_targetSystem_targetCode: {
+              sourceSystem: "YOSEMITECODE",
+              sourceCode: group.winner,
+              targetSystem: mapping.targetSystem,
+              targetCode: mapping.targetCode,
+            },
+          },
+        });
+        if (existing) {
+          // The winner already maps to the same target - the loser's row
+          // would only collide with the unique constraint if repointed.
+          await prisma.codeMapping.delete({ where: { id: mapping.id } });
+          mappingsDeduped += 1;
+        } else {
+          await prisma.codeMapping.update({
+            where: { id: mapping.id },
+            data: { sourceCode: group.winner },
+          });
+          mappingsRepointed += 1;
+        }
+      }
+
+      await prisma.codeEntry.update({
+        where: { system_code: { system: "YOSEMITECODE", code: loser } },
+        data: { active: false },
+      });
+      entriesDeactivated += 1;
+    }
+  }
+
+  console.log(
+    `\nwrote: ${patientsRepointed} patients repointed, ${mappingsRepointed} mappings repointed, ` +
+      `${mappingsDeduped} duplicate mappings removed, ${entriesDeactivated} entries deactivated`,
+  );
+};
+
+/**
+ * Only run when this file IS the command, not when a test imports planDedupe.
+ * argv[1] rather than require.main, which is not defined under ESM.
+ */
+const invokedDirectly = (process.argv[1] ?? "").includes("dedupe-breed-codes");
+
+if (invokedDirectly) {
+  main()
+    .catch((error) => {
+      console.error(error);
+      process.exitCode = 1;
+    })
+    .finally(() => prisma.$disconnect());
+}

--- a/apps/backend/src/scripts/dedupe-breed-codes.ts
+++ b/apps/backend/src/scripts/dedupe-breed-codes.ts
@@ -60,10 +60,9 @@ export const planDedupe = async (): Promise<DedupePlan> => {
   for (const entry of entries) {
     const canonical = canonicalBreedCode(entry.code);
     if (!canonical) continue;
-    byCanonical.set(canonical, [
-      ...(byCanonical.get(canonical) ?? []),
-      entry.code,
-    ]);
+    const codes = byCanonical.get(canonical) ?? [];
+    codes.push(entry.code);
+    byCanonical.set(canonical, codes);
   }
 
   const groups: DedupeGroup[] = [];
@@ -123,7 +122,23 @@ export const main = async () => {
   let mappingsDeduped = 0;
   let entriesDeactivated = 0;
 
+  const mappingKey = (targetSystem: string, targetCode: string) =>
+    `${targetSystem}:${targetCode}`;
+
   for (const group of groups) {
+    // Fetched once per group rather than once per loser mapping (an N+1
+    // read otherwise) and kept up to date as losers are repointed, so a
+    // second loser mapping to the same target is deduped instead of
+    // colliding with the unique (sourceSystem, sourceCode, targetSystem,
+    // targetCode) constraint the first repoint would already have claimed.
+    const winnerMappings = await prisma.codeMapping.findMany({
+      where: { sourceSystem: "YOSEMITECODE", sourceCode: group.winner },
+      select: { targetSystem: true, targetCode: true },
+    });
+    const winnerTargets = new Set(
+      winnerMappings.map((m) => mappingKey(m.targetSystem, m.targetCode)),
+    );
+
     for (const loser of group.losers) {
       const patientResult = await prisma.patient.updateMany({
         where: { breedCode: loser },
@@ -135,19 +150,8 @@ export const main = async () => {
         where: { sourceSystem: "YOSEMITECODE", sourceCode: loser },
       });
       for (const mapping of loserMappings) {
-        const existing = await prisma.codeMapping.findUnique({
-          where: {
-            sourceSystem_sourceCode_targetSystem_targetCode: {
-              sourceSystem: "YOSEMITECODE",
-              sourceCode: group.winner,
-              targetSystem: mapping.targetSystem,
-              targetCode: mapping.targetCode,
-            },
-          },
-        });
-        if (existing) {
-          // The winner already maps to the same target - the loser's row
-          // would only collide with the unique constraint if repointed.
+        const key = mappingKey(mapping.targetSystem, mapping.targetCode);
+        if (winnerTargets.has(key)) {
           await prisma.codeMapping.delete({ where: { id: mapping.id } });
           mappingsDeduped += 1;
         } else {
@@ -156,6 +160,7 @@ export const main = async () => {
             data: { sourceCode: group.winner },
           });
           mappingsRepointed += 1;
+          winnerTargets.add(key);
         }
       }
 

--- a/apps/backend/test/scripts/dedupe-breed-codes.test.ts
+++ b/apps/backend/test/scripts/dedupe-breed-codes.test.ts
@@ -1,0 +1,204 @@
+jest.mock("src/config/prisma", () => ({
+  prisma: {
+    codeEntry: { findMany: jest.fn(), update: jest.fn() },
+    codeMapping: {
+      findMany: jest.fn(),
+      findUnique: jest.fn(),
+      update: jest.fn(),
+      delete: jest.fn(),
+    },
+    patient: { updateMany: jest.fn() },
+    $disconnect: jest.fn(),
+  },
+}));
+
+import { prisma } from "src/config/prisma";
+import { main, planDedupe } from "src/scripts/dedupe-breed-codes";
+
+const mocked = prisma as unknown as {
+  codeEntry: { findMany: jest.Mock; update: jest.Mock };
+  codeMapping: {
+    findMany: jest.Mock;
+    findUnique: jest.Mock;
+    update: jest.Mock;
+    delete: jest.Mock;
+  };
+  patient: { updateMany: jest.Mock };
+};
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("planDedupe", () => {
+  it("picks the code that already equals its own canonical form as the winner", async () => {
+    mocked.codeEntry.findMany.mockResolvedValue([
+      { code: "YBREED:CANINE:SHIH_TZU" },
+      { code: "YBREED:CANINE:SHIH-TZU" },
+    ]);
+
+    const { groups, unresolved } = await planDedupe();
+
+    expect(unresolved).toEqual([]);
+    expect(groups).toEqual([
+      {
+        canonical: "YBREED:CANINE:SHIH_TZU",
+        winner: "YBREED:CANINE:SHIH_TZU",
+        losers: ["YBREED:CANINE:SHIH-TZU"],
+      },
+    ]);
+  });
+
+  it("leaves a breed with only one spelling alone", async () => {
+    mocked.codeEntry.findMany.mockResolvedValue([
+      { code: "YBREED:CANINE:PUG" },
+    ]);
+
+    const { groups, unresolved } = await planDedupe();
+
+    expect(groups).toEqual([]);
+    expect(unresolved).toEqual([]);
+  });
+
+  it("reports unresolved when neither spelling already matches the canonical form", async () => {
+    // Both rows carry a hyphen - the fold-together step would have to guess,
+    // so it refuses instead. A wrong repoint is worse than a duplicate left.
+    mocked.codeEntry.findMany.mockResolvedValue([
+      { code: "YBREED:CANINE:APPALOOSA-X" },
+      { code: "ybreed:canine:appaloosa-x" },
+    ]);
+
+    const { groups, unresolved } = await planDedupe();
+
+    expect(groups).toEqual([]);
+    expect(unresolved).toEqual([
+      {
+        canonical: "YBREED:CANINE:APPALOOSA_X",
+        codes: ["YBREED:CANINE:APPALOOSA-X", "ybreed:canine:appaloosa-x"],
+        reason: "no code already matches the canonical form",
+      },
+    ]);
+  });
+
+  it("queries only active-agnostic BREED entries in the YOSEMITECODE system", async () => {
+    mocked.codeEntry.findMany.mockResolvedValue([]);
+    await planDedupe();
+    expect(mocked.codeEntry.findMany).toHaveBeenCalledWith({
+      where: { system: "YOSEMITECODE", type: "BREED" },
+      select: { code: true },
+    });
+  });
+});
+
+describe("main", () => {
+  let log: jest.SpyInstance;
+  let argv: string[];
+
+  beforeEach(() => {
+    argv = process.argv;
+    log = jest.spyOn(console, "log").mockImplementation(() => {});
+    mocked.codeEntry.findMany.mockResolvedValue([
+      { code: "YBREED:CANINE:SHIH_TZU" },
+      { code: "YBREED:CANINE:SHIH-TZU" },
+    ]);
+    mocked.patient.updateMany.mockResolvedValue({ count: 1 });
+    mocked.codeMapping.findMany.mockResolvedValue([]);
+    mocked.codeEntry.update.mockResolvedValue({});
+  });
+
+  afterEach(() => {
+    process.argv = argv;
+    log.mockRestore();
+  });
+
+  const output = () => log.mock.calls.map((c) => String(c[0])).join("\n");
+
+  it("writes nothing without --apply", async () => {
+    process.argv = ["node", "dedupe-breed-codes.ts"];
+    await main();
+
+    expect(mocked.patient.updateMany).not.toHaveBeenCalled();
+    expect(mocked.codeEntry.update).not.toHaveBeenCalled();
+    expect(output()).toMatch(/dry run/);
+  });
+
+  it("repoints patients off the loser code and onto the winner", async () => {
+    process.argv = ["node", "dedupe-breed-codes.ts", "--apply"];
+    await main();
+
+    expect(mocked.patient.updateMany).toHaveBeenCalledWith({
+      where: { breedCode: "YBREED:CANINE:SHIH-TZU" },
+      data: { breedCode: "YBREED:CANINE:SHIH_TZU" },
+    });
+  });
+
+  it("deactivates the loser entry rather than deleting it", async () => {
+    process.argv = ["node", "dedupe-breed-codes.ts", "--apply"];
+    await main();
+
+    expect(mocked.codeEntry.update).toHaveBeenCalledWith({
+      where: {
+        system_code: { system: "YOSEMITECODE", code: "YBREED:CANINE:SHIH-TZU" },
+      },
+      data: { active: false },
+    });
+  });
+
+  it("repoints a mapping's sourceCode when the winner has no equivalent mapping yet", async () => {
+    mocked.codeMapping.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        sourceSystem: "YOSEMITECODE",
+        sourceCode: "YBREED:CANINE:SHIH-TZU",
+        targetSystem: "IDEXX",
+        targetCode: "IDX-9",
+      },
+    ]);
+    mocked.codeMapping.findUnique.mockResolvedValue(null);
+    process.argv = ["node", "dedupe-breed-codes.ts", "--apply"];
+
+    await main();
+
+    expect(mocked.codeMapping.update).toHaveBeenCalledWith({
+      where: { id: "m1" },
+      data: { sourceCode: "YBREED:CANINE:SHIH_TZU" },
+    });
+    expect(mocked.codeMapping.delete).not.toHaveBeenCalled();
+    expect(output()).toMatch(/1 mappings repointed/);
+  });
+
+  it("deletes the loser's mapping instead of repointing when the winner already has that target", async () => {
+    // Repointing here would collide with the unique
+    // (sourceSystem, sourceCode, targetSystem, targetCode) constraint.
+    mocked.codeMapping.findMany.mockResolvedValue([
+      {
+        id: "m1",
+        sourceSystem: "YOSEMITECODE",
+        sourceCode: "YBREED:CANINE:SHIH-TZU",
+        targetSystem: "IDEXX",
+        targetCode: "IDX-9",
+      },
+    ]);
+    mocked.codeMapping.findUnique.mockResolvedValue({ id: "m2" });
+    process.argv = ["node", "dedupe-breed-codes.ts", "--apply"];
+
+    await main();
+
+    expect(mocked.codeMapping.delete).toHaveBeenCalledWith({
+      where: { id: "m1" },
+    });
+    expect(mocked.codeMapping.update).not.toHaveBeenCalled();
+    expect(output()).toMatch(/1 duplicate mappings removed/);
+  });
+
+  it("names every unresolved group and why", async () => {
+    mocked.codeEntry.findMany.mockResolvedValue([
+      { code: "YBREED:CANINE:APPALOOSA-X" },
+      { code: "ybreed:canine:appaloosa-x" },
+    ]);
+    process.argv = ["node", "dedupe-breed-codes.ts"];
+
+    await main();
+
+    expect(output()).toMatch(/SKIP YBREED:CANINE:APPALOOSA_X/);
+    expect(output()).toMatch(/no code already matches/);
+  });
+});

--- a/apps/backend/test/scripts/dedupe-breed-codes.test.ts
+++ b/apps/backend/test/scripts/dedupe-breed-codes.test.ts
@@ -3,7 +3,6 @@ jest.mock("src/config/prisma", () => ({
     codeEntry: { findMany: jest.fn(), update: jest.fn() },
     codeMapping: {
       findMany: jest.fn(),
-      findUnique: jest.fn(),
       update: jest.fn(),
       delete: jest.fn(),
     },
@@ -19,7 +18,6 @@ const mocked = prisma as unknown as {
   codeEntry: { findMany: jest.Mock; update: jest.Mock };
   codeMapping: {
     findMany: jest.Mock;
-    findUnique: jest.Mock;
     update: jest.Mock;
     delete: jest.Mock;
   };
@@ -142,17 +140,20 @@ describe("main", () => {
     });
   });
 
+  const loserMapping = {
+    id: "m1",
+    sourceSystem: "YOSEMITECODE",
+    sourceCode: "YBREED:CANINE:SHIH-TZU",
+    targetSystem: "IDEXX",
+    targetCode: "IDX-9",
+  };
+
   it("repoints a mapping's sourceCode when the winner has no equivalent mapping yet", async () => {
-    mocked.codeMapping.findMany.mockResolvedValue([
-      {
-        id: "m1",
-        sourceSystem: "YOSEMITECODE",
-        sourceCode: "YBREED:CANINE:SHIH-TZU",
-        targetSystem: "IDEXX",
-        targetCode: "IDX-9",
-      },
-    ]);
-    mocked.codeMapping.findUnique.mockResolvedValue(null);
+    mocked.codeMapping.findMany.mockImplementation(({ where }) =>
+      Promise.resolve(
+        where.sourceCode === "YBREED:CANINE:SHIH-TZU" ? [loserMapping] : [],
+      ),
+    );
     process.argv = ["node", "dedupe-breed-codes.ts", "--apply"];
 
     await main();
@@ -168,16 +169,13 @@ describe("main", () => {
   it("deletes the loser's mapping instead of repointing when the winner already has that target", async () => {
     // Repointing here would collide with the unique
     // (sourceSystem, sourceCode, targetSystem, targetCode) constraint.
-    mocked.codeMapping.findMany.mockResolvedValue([
-      {
-        id: "m1",
-        sourceSystem: "YOSEMITECODE",
-        sourceCode: "YBREED:CANINE:SHIH-TZU",
-        targetSystem: "IDEXX",
-        targetCode: "IDX-9",
-      },
-    ]);
-    mocked.codeMapping.findUnique.mockResolvedValue({ id: "m2" });
+    mocked.codeMapping.findMany.mockImplementation(({ where }) =>
+      Promise.resolve(
+        where.sourceCode === "YBREED:CANINE:SHIH-TZU"
+          ? [loserMapping]
+          : [{ targetSystem: "IDEXX", targetCode: "IDX-9" }],
+      ),
+    );
     process.argv = ["node", "dedupe-breed-codes.ts", "--apply"];
 
     await main();
@@ -186,6 +184,39 @@ describe("main", () => {
       where: { id: "m1" },
     });
     expect(mocked.codeMapping.update).not.toHaveBeenCalled();
+    expect(output()).toMatch(/1 duplicate mappings removed/);
+  });
+
+  it("dedupes a second loser mapping onto the same target the first loser was just repointed to", async () => {
+    // The winner has no mapping for this target before this group runs -
+    // the first loser's repoint is what creates it, and the second loser
+    // must see that in-memory update rather than re-querying and colliding.
+    mocked.codeEntry.findMany.mockResolvedValue([
+      { code: "YBREED:CANINE:SHIH_TZU" },
+      { code: "YBREED:CANINE:SHIH-TZU" },
+      { code: "ybreed:canine:shih_tzu" },
+    ]);
+    mocked.codeMapping.findMany.mockImplementation(({ where }) => {
+      if (where.sourceCode === "YBREED:CANINE:SHIH-TZU") {
+        return Promise.resolve([{ ...loserMapping, id: "m1" }]);
+      }
+      if (where.sourceCode === "ybreed:canine:shih_tzu") {
+        return Promise.resolve([{ ...loserMapping, id: "m2" }]);
+      }
+      return Promise.resolve([]);
+    });
+    process.argv = ["node", "dedupe-breed-codes.ts", "--apply"];
+
+    await main();
+
+    expect(mocked.codeMapping.update).toHaveBeenCalledWith({
+      where: { id: "m1" },
+      data: { sourceCode: "YBREED:CANINE:SHIH_TZU" },
+    });
+    expect(mocked.codeMapping.delete).toHaveBeenCalledWith({
+      where: { id: "m2" },
+    });
+    expect(output()).toMatch(/1 mappings repointed/);
     expect(output()).toMatch(/1 duplicate mappings removed/);
   });
 


### PR DESCRIPTION
Fixes #2450.

`CodeEntry` holds 36 breeds under both a hyphen and an underscore spelling (`YBREED:CANINE:SHIH_TZU` vs `YBREED:CANINE:SHIH-TZU`); the seven already-coded patients in production are split across both. Anything that joins on `breedCode` literally - reporting, PIMS filters, IDEXX reference ranges, an export - silently misses whichever half of the population is coded the other way.

## What this does

Adds `dedupe-breed-codes.ts`, mirroring `backfill-breed-codes.ts`'s dry-run / `--apply` convention:

- Groups every `BREED` `CodeEntry` by its canonical form (`canonicalBreedCode`, already shipped for #2449).
- The winner in each duplicate group is the code that already equals its own canonical form - underscore wins, since the live `buildBreedCode` generator in `idexx-reference.service.ts` has always emitted underscores. A pair where neither (or both) sides already match is reported **unresolved**, not guessed at.
- On `--apply`: `Patient.breedCode` rows and `CodeMapping` rows pointing at the losing code are repointed to the winner - or the mapping is dropped instead, if the winner already has an equivalent one, to avoid colliding with the `(sourceSystem, sourceCode, targetSystem, targetCode)` unique constraint. The losing `CodeEntry` is deactivated (`active: false`), not deleted, matching how the rest of the vocabulary already treats inactive rows as invisible.

## Deliberately not included

Both are open decisions the issue itself flags, not part of "one code per breed":

- A foreign key from `Patient.breedCode` to `CodeEntry.code` - this fix is the prerequisite (duplicates resolved), but enforcing it is a separate call.
- Making `canonicalBreedCode` the single write path everywhere a breed code is created - the only live writer (`buildBreedCode`) already emits the canonical form; nothing today writes a fresh hyphenated code.

## Testing

- `npx jest test/scripts/dedupe-breed-codes.test.ts` - 10/10 pass, mutation-checked (broke winner-selection and the mapping-dedup branch, both caught by the suite, then reverted).
- Full backend suite: `npx jest` - 492 suites / 11693 tests pass.
- `npx tsc --noEmit` clean, `npx eslint .` clean (0 errors) after building the workspace packages.