### PR TITLE
fix(backend): quarantine idexx results without ids

### DIFF
--- a/apps/backend/src/services/idexx-results.service.ts
+++ b/apps/backend/src/services/idexx-results.service.ts
@@ -39,6 +39,11 @@ const coerceString = (value: unknown): string | null => {
 const coerceStringOrEmpty = (value: unknown): string =>
   coerceString(value) ?? "";
 
+const coerceNonBlankString = (value: unknown): string | null => {
+  const coerced = coerceString(value);
+  return coerced?.trim() ? coerced : null;
+};
+
 /**
  * `organisationId` is the tenant key that lab-result reads authorize on, so it is taken from
  * the LabOrder we placed rather than from the provider's response, which is outside our
@@ -305,15 +310,21 @@ const maybeCreateResultArtifacts = async (
  * reason needs no migration; every value in use is named here.
  */
 export const QUARANTINE_REASON_UNMAPPED_STATUS = "UNMAPPED_RESULT_STATUS";
+export const QUARANTINE_REASON_MISSING_RESULT_ID = "MISSING_RESULT_ID";
+
+type QuarantineReason =
+  | typeof QUARANTINE_REASON_UNMAPPED_STATUS
+  | typeof QUARANTINE_REASON_MISSING_RESULT_ID;
 
 type UnapplicableResult = {
   result: IdexxResult;
   context: ResultOrderContext;
+  reason: QuarantineReason;
 };
 
 /**
- * Record a result the mapper could not apply, so the rest of its batch can be
- * confirmed.
+ * Record a result that could not be applied safely, so the rest of its batch
+ * can be confirmed.
  *
  * IDEXX confirms a BATCH, and `pollLatest` builds ONE client from
  * `IDEXX_GLOBAL_USERNAME` with `organisationId` derived per result. So refusing
@@ -322,10 +333,9 @@ type UnapplicableResult = {
  * unconfirmed batch is re-fetched on the next poll and meets the same row
  * again.
  *
- * Writing the row here is what makes confirming the rest safe. The LabOrder
- * transition is still not applied - that part of #2699 is unchanged and
- * deliberate - but it is now held in a queryable place with the payload needed
- * to replay it, rather than depending on the batch being re-sent forever.
+ * Writing the row here is what makes confirming the rest safe. The provider
+ * payload is held in a queryable place for investigation or replay rather than
+ * depending on the batch being re-sent forever.
  *
  * `create`, not `upsert`: this table has no unique key on purpose (see the
  * model comment), because collapsing two rows onto a key is exactly the silent
@@ -350,7 +360,7 @@ const quarantineOperation = (
   batchId: string,
   result: IdexxResult,
   context: ResultOrderContext,
-  reason: string,
+  reason: QuarantineReason,
 ) =>
   prisma.labResultQuarantine.create({
     data: {
@@ -358,7 +368,7 @@ const quarantineOperation = (
       batchId,
       // Null rather than "" when the provider sent nothing usable: an absent id
       // is worth seeing as absent.
-      resultId: coerceString(result.resultId),
+      resultId: coerceNonBlankString(result.resultId),
       orderId: coerceString(result.orderId),
       labOrderId: context.labOrderId,
       organisationId: context.organisationId,
@@ -371,7 +381,7 @@ const quarantineOperation = (
   });
 
 /**
- * Hold every result in this batch the mapper could not apply.
+ * Hold every result in this batch that could not be applied safely.
  *
  * Answers the only question the caller has: is this batch now safe to confirm.
  * False means nothing is holding the skipped transition, so confirming would
@@ -397,25 +407,20 @@ const quarantineUnapplicable = async (
     // This costs the no-unique-key decision nothing: that is about two distinct
     // rows in one batch, this is about one row written twice across polls.
     await prisma.$transaction(
-      unapplicable.map(({ result, context }) =>
-        quarantineOperation(
-          batchId,
-          result,
-          context,
-          QUARANTINE_REASON_UNMAPPED_STATUS,
-        ),
+      unapplicable.map(({ result, context, reason }) =>
+        quarantineOperation(batchId, result, context, reason),
       ),
     );
   } catch (err) {
     logger.error(
-      "IDEXX batch left unconfirmed: could not quarantine an unmapped result",
+      "IDEXX batch left unconfirmed: could not quarantine an unapplicable result",
       { batchId, err },
     );
     return false;
   }
 
   logger.error(
-    "IDEXX results quarantined: a result status did not map to a LabOrder status",
+    "IDEXX results quarantined: one or more results could not be applied",
     { batchId, quarantined: unapplicable.length },
   );
   return true;
@@ -424,12 +429,28 @@ const quarantineUnapplicable = async (
 const processIdexxResult = async (
   client: IdexxResultsClient,
   result: IdexxResult,
-) => {
+): Promise<{
+  context: ResultOrderContext;
+  quarantineReason: QuarantineReason | null;
+}> => {
   const context = await syncLabOrderFromResult(result);
-  const resultId = coerceStringOrEmpty(result.resultId);
+  const resultId = coerceNonBlankString(result.resultId);
+  if (!resultId) {
+    logger.warn("IDEXX result quarantined: missing result id", {
+      orderId: coerceString(result.orderId),
+      organisationId: context.organisationId,
+    });
+    return { context, quarantineReason: QUARANTINE_REASON_MISSING_RESULT_ID };
+  }
+
   await upsertLabResult(result, resultId, context.organisationId);
   await maybeCreateResultArtifacts(client, result, resultId, context);
-  return context;
+  return {
+    context,
+    quarantineReason: context.unmappedStatus
+      ? QUARANTINE_REASON_UNMAPPED_STATUS
+      : null,
+  };
 };
 
 const recordBatchSyncState = async (
@@ -483,9 +504,12 @@ export const IdexxResultsService = {
 
       const unapplicable: UnapplicableResult[] = [];
       for (const result of results as IdexxResult[]) {
-        const context = await processIdexxResult(client, result);
-        if (context.unmappedStatus) {
-          unapplicable.push({ result, context });
+        const { context, quarantineReason } = await processIdexxResult(
+          client,
+          result,
+        );
+        if (quarantineReason) {
+          unapplicable.push({ result, context, reason: quarantineReason });
         }
       }
 

--- a/apps/backend/test/services/idexx-results.service.test.ts
+++ b/apps/backend/test/services/idexx-results.service.test.ts
@@ -280,7 +280,7 @@ describe("IdexxResultsService", () => {
       }),
     );
     expect(mockedLogger.error).toHaveBeenCalledWith(
-      "IDEXX results quarantined: a result status did not map to a LabOrder status",
+      "IDEXX results quarantined: one or more results could not be applied",
       { batchId: "batch-1", quarantined: 1 },
     );
   });
@@ -313,9 +313,71 @@ describe("IdexxResultsService", () => {
     expect(mockConfirmLatestBatch).not.toHaveBeenCalled();
     expect(mockedPrisma.labResultSyncState.upsert).not.toHaveBeenCalled();
     expect(mockedLogger.error).toHaveBeenCalledWith(
-      "IDEXX batch left unconfirmed: could not quarantine an unmapped result",
+      "IDEXX batch left unconfirmed: could not quarantine an unapplicable result",
       expect.objectContaining({ batchId: "batch-1" }),
     );
+  });
+
+  it("quarantines every result with no usable id without writing a LabResult", async () => {
+    mockedPrisma.labOrder.findFirst
+      .mockResolvedValueOnce({
+        id: "lab-order-1",
+        organisationId: "org-1",
+        appointmentId: "appointment-1",
+        createdByUserId: "user-1",
+        patientId: "patient-1",
+      } as any)
+      .mockResolvedValueOnce({
+        id: "lab-order-2",
+        organisationId: "org-2",
+        appointmentId: "appointment-2",
+        createdByUserId: "user-2",
+        patientId: "patient-2",
+      } as any);
+    mockGetLatestResults.mockResolvedValue({
+      batchId: "batch-1",
+      hasMoreResults: false,
+      results: [
+        {
+          orderId: "order-1",
+          status: "COMPLETE",
+          updatedDate: "2026-06-17T12:00:00.000Z",
+          patient: { patientId: "patient-1" },
+        },
+        {
+          resultId: "   ",
+          orderId: "order-2",
+          status: "COMPLETE",
+          updatedDate: "2026-06-17T12:05:00.000Z",
+          patient: { patientId: "patient-2" },
+        },
+      ],
+    });
+
+    await IdexxResultsService.pollLatest(2, 1);
+
+    expect(mockedPrisma.labResult.upsert).not.toHaveBeenCalled();
+    expect(mockedDocumentService.create).not.toHaveBeenCalled();
+    expect(mockedTaskService.createCustom).not.toHaveBeenCalled();
+    expect(mockedPrisma.labResultQuarantine.create).toHaveBeenCalledTimes(2);
+    expect(mockedPrisma.labResultQuarantine.create).toHaveBeenNthCalledWith(1, {
+      data: expect.objectContaining({
+        resultId: null,
+        orderId: "order-1",
+        organisationId: "org-1",
+        reason: "MISSING_RESULT_ID",
+      }),
+    });
+    expect(mockedPrisma.labResultQuarantine.create).toHaveBeenNthCalledWith(2, {
+      data: expect.objectContaining({
+        resultId: null,
+        orderId: "order-2",
+        organisationId: "org-2",
+        reason: "MISSING_RESULT_ID",
+      }),
+    });
+    expect(mockConfirmLatestBatch).toHaveBeenCalledWith("batch-1");
+    expect(mockedPrisma.labResultSyncState.upsert).toHaveBeenCalled();
   });
 
   // One row per unapplicable result, including when the provider sent no result id at all.


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## What is the current behavior?

IDEXX results without a usable `resultId` are coerced to an empty string and upserted through the shared `(provider, resultId)` unique key. Multiple id-less results therefore overwrite one `LabResult`, including its organization assignment.

## What is the new behavior?

Results with an absent or blank `resultId` skip the `LabResult` upsert and artifact creation. Each one is recorded independently in the existing lab result quarantine with reason `MISSING_RESULT_ID`, preserving its provider payload and organization context before the IDEXX batch is confirmed. Existing unmapped-status quarantine behavior now carries its reason per result through the same transaction.

The focused IDEXX service suite covers two id-less results from different organizations and asserts that neither reaches the shared upsert key, both quarantine rows survive, and batch ingestion advances. Disabling the missing-ID guard makes this test fail.

Validation:

- Targeted IDEXX service suite: 11 tests passed.
- Targeted service coverage: 98.3% statements and lines, 75% branches, 100% functions.
- Backend TypeScript check passed.
- Full pre-push lint and type-check gates passed across the monorepo.

## Related Issue(s)

Fixes #2717
