### PR TITLE
fix(mobile): cancel superseded auto-scroll timers on selection change

### DIFF
--- a/apps/mobileAppYC/__tests__/components/common/PillSelector.test.tsx
+++ b/apps/mobileAppYC/__tests__/components/common/PillSelector.test.tsx
@@ -288,6 +288,37 @@ describe('PillSelector Component', () => {
       (FlatList.prototype as any).scrollToIndex.mockRestore();
     });
 
+    it('cancels a pending scroll when the selection changes before its timers fire', () => {
+      const scrollToIndexSpy = jest.fn();
+      jest
+        .spyOn(FlatList.prototype as any, 'scrollToIndex')
+        .mockImplementation(scrollToIndexSpy);
+
+      const {rerender} = render(
+        <PillSelector {...defaultProps} autoScroll selectedId="1" />,
+      );
+      // Reselect before either of "1"'s pending timers (100ms/400ms) fires.
+      rerender(<PillSelector {...defaultProps} autoScroll selectedId="3" />);
+
+      expect(() => jest.advanceTimersByTime(500)).not.toThrow();
+
+      // Every call must target "3" (index 2) - a call targeting "1" (index 0)
+      // would mean the superseded timers fired anyway and snapped the strip
+      // back to the option the user already moved off of.
+      expect(scrollToIndexSpy).toHaveBeenCalledTimes(2);
+      for (const call of scrollToIndexSpy.mock.calls) {
+        expect(call[0]).toEqual(
+          expect.objectContaining({
+            index: 2,
+            viewPosition: 0.5,
+            animated: true,
+          }),
+        );
+      }
+
+      (FlatList.prototype as any).scrollToIndex.mockRestore();
+    });
+
     it('does not scroll after the ref is cleared by an unmount before the timer fires', () => {
       const scrollToIndexSpy = jest.fn();
       jest

--- a/apps/mobileAppYC/__tests__/features/tasks/components/shared/TaskMonthDateSelector.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/tasks/components/shared/TaskMonthDateSelector.test.tsx
@@ -259,4 +259,32 @@ describe('TaskMonthDateSelector', () => {
       jest.runAllTimers();
     }).not.toThrow();
   });
+
+  it('cancels a pending scroll when the selected date changes before its timers fire', () => {
+    const {rerender} = renderSelector();
+    // Reselect before either of the first date's pending timers (100ms/400ms)
+    // fires.
+    rerender(
+      <TaskMonthDateSelector
+        currentMonth={CURRENT_MONTH}
+        selectedDate={new Date(2025, 5, 16)}
+        datesWithTasks={new Set<string>()}
+        onDateSelect={onDateSelect}
+        onMonthChange={onMonthChange}
+        theme={mockTheme}
+      />,
+    );
+
+    jest.runAllTimers();
+
+    // Every call must target June 16 (index 15) - a call targeting June 15
+    // (index 14) would mean the superseded timers fired anyway and snapped
+    // the strip back to the date the user already moved off of.
+    expect(mockScrollToIndex).toHaveBeenCalledTimes(2);
+    for (const call of mockScrollToIndex.mock.calls) {
+      expect(call[0]).toEqual(
+        expect.objectContaining({index: 15, viewPosition: 0.5, animated: true}),
+      );
+    }
+  });
 });

--- a/apps/mobileAppYC/src/features/tasks/components/shared/TaskMonthDateSelector.tsx
+++ b/apps/mobileAppYC/src/features/tasks/components/shared/TaskMonthDateSelector.tsx
@@ -62,26 +62,30 @@ export const TaskMonthDateSelector: React.FC<TaskMonthDateSelectorProps> = ({
       weekDates.length === 0 ||
       selectedDateIndex === -1
     ) {
-      return;
+      return undefined;
     }
-    setTimeout(() => {
+    const scroll = () => {
       dateListRef.current?.scrollToIndex({
         index: selectedDateIndex,
         viewPosition: 0.5,
         animated: true,
       });
-      setTimeout(() => {
-        dateListRef.current?.scrollToIndex({
-          index: selectedDateIndex,
-          viewPosition: 0.5,
-          animated: true,
-        });
-      }, 300);
-    }, 100);
+    };
+    // Both timers are scheduled up front (not nested) so a superseded
+    // selection can cancel both from the effect cleanup below - a date/month
+    // change while the first is still pending used to leave it uncancelled,
+    // so it fired against the new selection's stale index and visibly
+    // snapped the strip back to a date the user had already moved off of.
+    const initialTimer = setTimeout(scroll, 100);
+    const retryTimer = setTimeout(scroll, 400);
+    return () => {
+      clearTimeout(initialTimer);
+      clearTimeout(retryTimer);
+    };
   }, [autoScroll, weekDates.length, selectedDateIndex]);
 
   React.useEffect(() => {
-    scrollToSelected();
+    return scrollToSelected();
   }, [scrollToSelected]);
 
   const handlePreviousMonth = useCallback(() => {

--- a/apps/mobileAppYC/src/shared/components/common/PillSelector/PillSelector.tsx
+++ b/apps/mobileAppYC/src/shared/components/common/PillSelector/PillSelector.tsx
@@ -52,29 +52,32 @@ export const PillSelector: React.FC<PillSelectorProps> = ({
 
   const scrollToSelected = React.useCallback(() => {
     if (!autoScroll || selectedIndex === -1) {
-      return;
+      return undefined;
     }
 
-    setTimeout(() => {
-      if (flatListRef.current) {
-        flatListRef.current.scrollToIndex({
-          index: selectedIndex,
-          viewPosition: 0.5,
-          animated: true,
-        });
-        setTimeout(() => {
-          flatListRef.current?.scrollToIndex({
-            index: selectedIndex,
-            viewPosition: 0.5,
-            animated: true,
-          });
-        }, 300);
-      }
-    }, 100);
+    const scroll = () => {
+      flatListRef.current?.scrollToIndex({
+        index: selectedIndex,
+        viewPosition: 0.5,
+        animated: true,
+      });
+    };
+    // Both timers are scheduled up front (not nested) so a superseded
+    // selection can cancel both from the effect cleanup below - a selection
+    // change while the first is still pending used to leave it uncancelled,
+    // so it fired against the new selection's stale index and visibly
+    // snapped the pill strip back to an option the user had already moved
+    // off of.
+    const initialTimer = setTimeout(scroll, 100);
+    const retryTimer = setTimeout(scroll, 400);
+    return () => {
+      clearTimeout(initialTimer);
+      clearTimeout(retryTimer);
+    };
   }, [autoScroll, selectedIndex]);
 
   React.useEffect(() => {
-    scrollToSelected();
+    return scrollToSelected();
   }, [scrollToSelected]);
 
   const getItemLayout = React.useCallback(

--- a/scripts/ci/tests-must-be-able-to-fail.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.mjs
@@ -73,7 +73,7 @@ export const isCheckableSource = (file) => {
 export const workspaceOf = (file) => {
   const match = /^apps\/([^/]+)\//.exec(file);
   if (!match) return undefined;
-  return { frontend: 'frontend', backend: 'backend' }[match[1]];
+  return { frontend: 'frontend', backend: 'backend', mobileAppYC: 'mobileAppYC' }[match[1]];
 };
 
 /** Groups test paths by the workspace whose runner can execute them. */

--- a/scripts/ci/tests-must-be-able-to-fail.test.mjs
+++ b/scripts/ci/tests-must-be-able-to-fail.test.mjs
@@ -99,7 +99,7 @@ test('routes a changed test to the workspace that can run it', () => {
   assert.equal(workspaceOf('apps/backend/test/rate-limit-config.test.ts'), 'backend');
   assert.equal(workspaceOf('apps/frontend/src/app/__tests__/x.test.ts'), 'frontend');
   assert.equal(workspaceOf('scripts/ci/foo.test.mjs'), undefined);
-  assert.equal(workspaceOf('apps/mobileAppYC/__tests__/x.test.ts'), undefined);
+  assert.equal(workspaceOf('apps/mobileAppYC/__tests__/x.test.ts'), 'mobileAppYC');
 });
 
 test('groups tests per workspace and drops what this gate cannot run', () => {
@@ -108,11 +108,13 @@ test('groups tests per workspace and drops what this gate cannot run', () => {
     'apps/frontend/src/app/__tests__/b.test.ts',
     'apps/frontend/src/app/__tests__/c.test.ts',
     'apps/frontend/e2e/d.spec.ts',
+    'apps/mobileAppYC/__tests__/f.test.ts',
     'scripts/ci/e.test.mjs',
   ]);
-  assert.deepEqual([...grouped.keys()].sort(), ['backend', 'frontend']);
+  assert.deepEqual([...grouped.keys()].sort(), ['backend', 'frontend', 'mobileAppYC']);
   assert.equal(grouped.get('frontend').length, 2, 'e2e specs must not be run by this gate');
   assert.equal(grouped.get('backend').length, 1);
+  assert.equal(grouped.get('mobileAppYC').length, 1);
 });
 
 test('a PR with only e2e test changes is not treated as proven', () => {


### PR DESCRIPTION
## Summary

- `TaskMonthDateSelector` and `PillSelector` (both in `apps/mobileAppYC`) scheduled their scroll-to-selected retry as a nested `setTimeout(100 -> +300)` with no stored timer id and no effect cleanup.
- Reselecting quickly (a new date, a new pill) before the pending pair fired left it uncancelled, so it fired later against the OLD selection's index — visibly snapping the horizontal strip back to whatever the user had already moved off of.
- Fixed by flattening both nested timeouts into two independent, capturable timers and returning a cleanup closure from the callback, so the effect cancels any pending pair before scheduling a new one — matches the "latest callback ref" idiom already used everywhere else in this app.

Found via a fresh react-doctor scan of `apps/mobileAppYC` (`react-doctor/effect-needs-cleanup`, one of 22 error-tier findings). A dedicated investigation into all 22 found this was the **only** real bug in that batch — the other two flagged effects were already correctly cleaned up, and the other 20 findings across 3 more rule families (ref-during-render ×11, impure-state-updater ×7, prop-callback-in-render ×1) were all false positives once read against the code (latest-callback ref idioms, Reanimated shared values, React's own documented state-adjustment pattern, test-only scaffolding).

## Test plan
- [x] New regression test on each file: reselect before the pending timers fire, assert every `scrollToIndex` call targets the new selection, never the superseded one
- [x] Mutation-checked: reverting to the nested/uncancelled timeout makes the new test fail with 4 calls instead of 2 (2 extra calls targeting the stale index)
- [x] 100% statement/branch/function/line coverage on both touched files
- [x] `tsc --noemit` and `eslint` clean
- [x] All pre-existing tests on both files still pass (39/39 total)