### PR TITLE
fix(ci): recognize the FolderName.stories.tsx naming this codebase uses

### DIFF
--- a/scripts/ci/story-coverage.mjs
+++ b/scripts/ci/story-coverage.mjs
@@ -129,6 +129,12 @@ export function storyPathFor(componentFile) {
 export function alternateStoryPathFor(componentFile) {
   if (path.basename(componentFile) !== 'index.tsx') return null;
   const dir = path.dirname(componentFile);
+  // Defense in depth: evaluate()'s resolveWithin() already rejects any
+  // resulting path that escapes cwd before it is ever read, but this checks
+  // `dir` itself (not just its basename, which a `..` segment further up the
+  // path would not appear in) so this function never even constructs a path
+  // reaching outside componentFile's own directory tree.
+  if (dir.split(path.sep).includes('..') || path.isAbsolute(dir)) return null;
   return path.join(dir, `${path.basename(dir)}.stories.tsx`);
 }
 

--- a/scripts/ci/story-coverage.mjs
+++ b/scripts/ci/story-coverage.mjs
@@ -116,6 +116,22 @@ export function storyPathFor(componentFile) {
   return componentFile.replace(/\.tsx$/, '.stories.tsx');
 }
 
+/**
+ * A component living at <Dir>/index.tsx is commonly storied in this codebase
+ * as <Dir>/<Dir-basename>.stories.tsx (36 instances measured) rather than
+ * <Dir>/index.stories.tsx (21 instances) - both are real, established
+ * conventions here, not a typo either way. Checking only storyPathFor's
+ * index.stories.tsx guess flagged 32 components with a real, working story
+ * as "missing" simply because the story followed the other convention.
+ * Returns null for a component not named index.tsx, where no such ambiguity
+ * exists.
+ */
+export function alternateStoryPathFor(componentFile) {
+  if (path.basename(componentFile) !== 'index.tsx') return null;
+  const dir = path.dirname(componentFile);
+  return path.join(dir, `${path.basename(dir)}.stories.tsx`);
+}
+
 // `files` comes from `git diff` output or a `--files` CLI argument, neither
 // of which this script should trust to stay under `cwd` - a relative path
 // containing `..` (or an absolute path) could otherwise make readFileSync
@@ -152,7 +168,13 @@ export function evaluate({ files, cwd = REPO_ROOT }) {
     checked.push(file);
     const storyFile = storyPathFor(file);
     const storyFullPath = resolveWithin(cwd, storyFile);
-    if (!storyFullPath || !existsSync(storyFullPath)) {
+    const hasPrimaryStory = !!storyFullPath && existsSync(storyFullPath);
+
+    const altStoryFile = alternateStoryPathFor(file);
+    const altStoryFullPath = altStoryFile ? resolveWithin(cwd, altStoryFile) : null;
+    const hasAltStory = !!altStoryFullPath && existsSync(altStoryFullPath);
+
+    if (!hasPrimaryStory && !hasAltStory) {
       missing.push({ file, expected: storyFile });
     }
   }

--- a/scripts/ci/story-coverage.test.mjs
+++ b/scripts/ci/story-coverage.test.mjs
@@ -10,7 +10,13 @@ import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 
-import { looksLikeComponent, storyPathFor, evaluate, parseArgs } from './story-coverage.mjs';
+import {
+  looksLikeComponent,
+  storyPathFor,
+  alternateStoryPathFor,
+  evaluate,
+  parseArgs,
+} from './story-coverage.mjs';
 
 const REAL_COMPONENT = `
 import React from 'react';
@@ -114,6 +120,19 @@ describe('storyPathFor', () => {
   });
 });
 
+describe('alternateStoryPathFor', () => {
+  it('names the folder-basename story for an index.tsx component', () => {
+    assert.equal(
+      alternateStoryPathFor('apps/frontend/src/app/ui/cards/TaskCard/index.tsx'),
+      'apps/frontend/src/app/ui/cards/TaskCard/TaskCard.stories.tsx'
+    );
+  });
+
+  it('returns null for a component not named index.tsx - no ambiguity to resolve', () => {
+    assert.equal(alternateStoryPathFor('apps/frontend/src/app/features/x/Foo.tsx'), null);
+  });
+});
+
 describe('parseArgs', () => {
   it('THE CASE THIS GATE EXISTS FOR: --files consumes every remaining argument, not just the first', () => {
     // Found via a real run against a historical commit: with a loop that
@@ -158,6 +177,31 @@ describe('evaluate', () => {
       writeFileSync(path.join(dir, 'Foo.stories.tsx'), 'export default {};');
       const { missing } = evaluate({ files: ['Foo.tsx'], cwd: dir });
       assert.deepEqual(missing, []);
+    });
+  });
+
+  it('does not flag an index.tsx component whose story uses the folder-basename convention', () => {
+    withFixture((dir) => {
+      const componentDir = path.join(dir, 'TaskCard');
+      mkdirSync(componentDir, { recursive: true });
+      writeFileSync(path.join(componentDir, 'index.tsx'), REAL_COMPONENT);
+      // Not index.stories.tsx - this is the other real convention this
+      // codebase uses, and storyPathFor alone would miss it.
+      writeFileSync(path.join(componentDir, 'TaskCard.stories.tsx'), 'export default {};');
+      const { missing } = evaluate({ files: ['TaskCard/index.tsx'], cwd: dir });
+      assert.deepEqual(missing, []);
+    });
+  });
+
+  it('still flags an index.tsx component with neither story naming present', () => {
+    withFixture((dir) => {
+      const componentDir = path.join(dir, 'TaskCard');
+      mkdirSync(componentDir, { recursive: true });
+      writeFileSync(path.join(componentDir, 'index.tsx'), REAL_COMPONENT);
+      const { missing } = evaluate({ files: ['TaskCard/index.tsx'], cwd: dir });
+      assert.deepEqual(missing, [
+        { file: 'TaskCard/index.tsx', expected: 'TaskCard/index.stories.tsx' },
+      ]);
     });
   });
 

--- a/scripts/ci/story-coverage.test.mjs
+++ b/scripts/ci/story-coverage.test.mjs
@@ -131,6 +131,15 @@ describe('alternateStoryPathFor', () => {
   it('returns null for a component not named index.tsx - no ambiguity to resolve', () => {
     assert.equal(alternateStoryPathFor('apps/frontend/src/app/features/x/Foo.tsx'), null);
   });
+
+  it("refuses to construct a path that escapes componentFile's own directory tree", () => {
+    // Defense in depth: evaluate()'s resolveWithin() would also reject the
+    // resulting path before ever reading it, but this must not even build
+    // a path pointing outside index.tsx's own directory in the first place.
+    assert.equal(alternateStoryPathFor('../../etc/index.tsx'), null);
+    assert.equal(alternateStoryPathFor('apps/frontend/../../etc/index.tsx'), null);
+    assert.equal(alternateStoryPathFor('/etc/index.tsx'), null);
+  });
 });
 
 describe('parseArgs', () => {


### PR DESCRIPTION
## Summary

- `storyPathFor()` in the story-coverage gate only ever checked `<Dir>/index.stories.tsx` for a component living at `<Dir>/index.tsx`.
- This codebase genuinely uses two conventions for that case — 36 components story as `<Dir>/<Dir-basename>.stories.tsx` (measured), 21 as `<Dir>/index.stories.tsx` — so the gate flagged 32 components with a real, working story as "missing" purely because they used the other, equally-established name.
- Found while doing a full audit of the current story-coverage gap (`node scripts/ci/story-coverage.mjs --files <every .tsx file>`): 73 "missing" before this fix. Cross-checked against the actual filesystem and confirmed 32 of those had a real sibling story under the folder-basename convention. After the fix: 41 — matching the independent filesystem check exactly.
- Added `alternateStoryPathFor()`, checked alongside the primary path before declaring a component missing.

## Test plan
- [x] New tests: an `index.tsx` component with only the folder-basename story is not flagged; one with neither naming present still is
- [x] Mutation-checked: removing the alternate-path check breaks the new "not flagged" test
- [x] Full `node --test scripts/ci/story-coverage.test.mjs` suite green (21/21)
- [x] Ran the fixed gate against every current `apps/frontend` `.tsx` file and confirmed the 41-file result matches an independent Python-based filesystem cross-check exactly