### PR TITLE
chore(frontend): close out the current story-coverage gap

### DIFF
--- a/apps/frontend/src/app/(routes)/(app)/appointments/[appointmentId]/workspace/loading.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/appointments/[appointmentId]/workspace/loading.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { YosemiteLoader } from '@/app/ui/overlays/Loader';
 
+// no-story: thin wrapper around the already-storied YosemiteLoader
 const Loading = () => (
   <main className="w-full px-4 py-5 sm:px-6 lg:px-8">
     <div className="flex min-h-[60vh] items-center justify-center">

--- a/apps/frontend/src/app/(routes)/(app)/appointments/loading.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/appointments/loading.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { YosemiteLoader } from '@/app/ui/overlays/Loader';
 
+// no-story: thin wrapper around the already-storied YosemiteLoader
 const Loading = () => (
   <div className="flex min-h-[50vh] items-center justify-center">
     <YosemiteLoader label="Loading appointments" size={96} testId="appointments-route-loader" />

--- a/apps/frontend/src/app/(routes)/(app)/chat/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/chat/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+// no-story: metadata-only Next.js layout, no visual content of its own
 export const metadata: Metadata = { title: 'Chat — Yosemite Crew' };
 
 type ChatLayoutProps = Readonly<{

--- a/apps/frontend/src/app/(routes)/(app)/chat/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/chat/page.tsx
@@ -18,6 +18,7 @@ import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import './page.css';
 
+// no-story: thin Next.js route wrapper (guards + deep-link state only); real content is ChatContainer, already storied
 const ChatContainer = dynamic(
   () =>
     import('@/app/features/chat/components/ChatContainer').then((m) => ({

--- a/apps/frontend/src/app/(routes)/(app)/developers/settings/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/developers/settings/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+// no-story: metadata-only Next.js layout, no visual content of its own
 export const metadata: Metadata = { title: 'Developer Settings — Yosemite Crew' };
 
 type DeveloperSettingsLayoutProps = Readonly<{

--- a/apps/frontend/src/app/(routes)/(app)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/layout.tsx
@@ -3,6 +3,7 @@ import { connection } from 'next/server';
 import SessionInitializer from '@/app/ui/layout/SessionInitializer';
 import ThemeScript from '@/app/ui/theme/ThemeScript';
 
+// no-story: pure structural wrapper (theme script + a display:contents scoping div) around SessionInitializer, which needs a real session/store context this route group's own tests already cover
 interface AppLayoutProps {
   children: React.ReactNode;
 }

--- a/apps/frontend/src/app/(routes)/(app)/network/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/network/page.tsx
@@ -5,6 +5,7 @@ import dynamic from 'next/dynamic';
 import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 
+// no-story: thin Next.js route wrapper (guards + Suspense only); real content is NetworkDirectory, already storied
 const NetworkDirectory = dynamic(
   () => import('@/app/features/federation/components/NetworkDirectory'),
   { ssr: false, loading: () => null }

--- a/apps/frontend/src/app/(routes)/(app)/public-booking-setup/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/public-booking-setup/page.tsx
@@ -4,6 +4,7 @@ import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
 import OrgGuard from '@/app/ui/layout/guards/OrgGuard';
 import PublicBookingSetup from '@/app/features/onboarding/pages/PublicBookingSetup/PublicBookingSetup';
 
+// no-story: thin Next.js route wrapper (guards + metadata only); real content is PublicBookingSetup, already storied
 export const metadata: Metadata = { title: 'Set up online booking — Yosemite Crew' };
 
 const Page = () => (

--- a/apps/frontend/src/app/(routes)/(book)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(book)/layout.tsx
@@ -22,6 +22,7 @@ import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
  * depends on that last one - every line that reached for --ink-faint now uses
  * --ink-muted - so a browser without :has() loses nothing.
  */
+// no-story: pure structural wrapper (pre-paint theme script + a display:contents scoping div); no visual content of its own
 export default function BookLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <>

--- a/apps/frontend/src/app/(routes)/(public)/about/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/about/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import { About } from '@/app/features/marketing/pages/About/About';
 
+// no-story: thin Next.js route wrapper; real content is About, already storied
 export const metadata: Metadata = {
   title: 'About · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/accessibility/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/accessibility/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import AccessibilityStatement from '@/app/features/legal/pages/AccessibilityStatement';
 
+// no-story: thin Next.js route wrapper; real content is AccessibilityStatement, already storied
 export const metadata: Metadata = {
   title: 'Accessibility Statement · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/accessibility/report/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/accessibility/report/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+// no-story: metadata-only Next.js layout, no visual content of its own
 export const metadata: Metadata = {
   title: 'Report an Accessibility Barrier — Yosemite Crew',
   description: 'Tell us about an accessibility problem you encountered on Yosemite Crew.',

--- a/apps/frontend/src/app/(routes)/(public)/accessibility/report/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/accessibility/report/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import AccessibilityReportClient from './AccessibilityReportClient';
 
+// no-story: thin Next.js route wrapper; real content is AccessibilityReportClient, already storied
 export const metadata: Metadata = {
   title: 'Report an Accessibility Issue | Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/auth/callback/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/auth/callback/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Suspense } from 'react';
 import AuthCallback from '@/app/features/auth/pages/AuthCallback/AuthCallback';
 
+// no-story: thin Next.js route wrapper; real content is AuthCallback, already storied
 export const metadata: Metadata = {
   title: 'Signing in · Yosemite Crew',
   robots: { index: false, follow: false },

--- a/apps/frontend/src/app/(routes)/(public)/contact-us/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/contact-us/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import ContactusPage from '@/app/features/marketing/pages/ContactusPage/ContactusPage';
 
+// no-story: thin Next.js route wrapper; real content is ContactusPage, already storied
 export const metadata: Metadata = {
   title: 'Contact · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/developers/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/developers/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import { DevelopersPage } from '@/app/features/marketing/pages/DevelopersPage/DevelopersPage';
 
+// no-story: thin Next.js route wrapper; real content is DevelopersPage, already storied
 export const metadata: Metadata = {
   title: 'Developers · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/developers/signin/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/developers/signin/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 
 import SignIn from '@/app/features/auth/pages/SignIn/SignIn';
 
+// no-story: thin Next.js route wrapper; real content is SignIn, already storied (developer variant is a prop, exercised in SignIn.stories.tsx)
 export const metadata: Metadata = {
   title: 'Developer Sign In — Yosemite Crew',
   description: 'Sign in to your Yosemite Crew developer account.',

--- a/apps/frontend/src/app/(routes)/(public)/developers/signup/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/developers/signup/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 
 import SignUp from '@/app/features/auth/pages/SignUp/SignUp';
 
+// no-story: thin Next.js route wrapper; real content is SignUp, already storied (developer variant is a prop, exercised in SignUp.stories.tsx)
 export const metadata: Metadata = {
   title: 'Developer Sign Up — Yosemite Crew',
   description: 'Create a developer account to build on the Yosemite Crew platform.',

--- a/apps/frontend/src/app/(routes)/(public)/dmca/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/dmca/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import DmcaCopyrightPolicy from '@/app/features/legal/pages/DmcaCopyrightPolicy';
 
+// no-story: thin Next.js route wrapper; real content is DmcaCopyrightPolicy, already storied
 export const metadata: Metadata = {
   title: 'DMCA Copyright Policy · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/impressum/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/impressum/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import Impressum from '@/app/features/legal/pages/Impressum';
 
+// no-story: thin Next.js route wrapper; real content is Impressum, already storied
 export const metadata: Metadata = {
   title: 'Impressum · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/insights/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/insights/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import { Insights } from '@/app/features/marketing/pages/Insights/Insights';
 
+// no-story: thin Next.js route wrapper; real content is Insights, already storied
 export const metadata: Metadata = {
   title: 'Insights · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/layout.tsx
@@ -2,6 +2,7 @@ import '@/app/features/marketing/site/marketing.css';
 
 import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
 
+// no-story: pure pass-through that only pulls in a stylesheet and a pre-paint script; no visual content of its own
 interface PublicLayoutProps {
   children: React.ReactNode;
 }

--- a/apps/frontend/src/app/(routes)/(public)/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import { Home } from '@/app/features/marketing/pages/Home/Home';
 
+// no-story: thin Next.js route wrapper; real content is Home, already storied at src/app/features/marketing/pages/Home/Home.stories.tsx
 export const metadata: Metadata = {
   title: 'See the whole animal · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+// no-story: metadata-only Next.js layout (a bare <main> landmark), no visual content of its own
 export const metadata: Metadata = { title: 'Payment Status — Yosemite Crew' };
 
 type PaymentStatusLayoutProps = Readonly<{

--- a/apps/frontend/src/app/(routes)/(public)/payment-status/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/payment-status/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import React, { Suspense } from 'react';
 import { PaymentStatusContent } from './PaymentStatusContent';
 
+// no-story: thin Next.js route wrapper; real content is PaymentStatusContent, already storied
 export const metadata: Metadata = {
   title: 'Payment Status — Yosemite Crew',
 };

--- a/apps/frontend/src/app/(routes)/(public)/pet-businesses/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/pet-businesses/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import { PetBusinesses } from '@/app/features/marketing/pages/PetBusinesses/PetBusinesses';
 
+// no-story: thin Next.js route wrapper; real content is PetBusinesses, already storied
 export const metadata: Metadata = {
   title: 'Pet Businesses · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/pet-parents/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/pet-parents/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import { PetParents } from '@/app/features/marketing/pages/PetParents/PetParents';
 
+// no-story: thin Next.js route wrapper; real content is PetParents, already storied
 export const metadata: Metadata = {
   title: 'Pet Parents · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/pricing/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/pricing/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import { Pricing } from '@/app/features/marketing/pages/Pricing/Pricing';
 
+// no-story: thin Next.js route wrapper; real content is Pricing, already storied
 export const metadata: Metadata = {
   title: 'Pricing · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/privacy-policy/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/privacy-policy/page.tsx
@@ -4,6 +4,7 @@ import { MarketingShell } from '@/app/features/marketing/site';
 import PrivacyPolicy from '@/app/features/legal/pages/PrivacyPolicy';
 import BackToSignup from '@/app/features/legal/components/BackToSignup';
 
+// no-story: thin Next.js route wrapper; real content is PrivacyPolicy, already storied
 export const metadata: Metadata = {
   title: 'Privacy policy · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/reset-password/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/reset-password/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 
 import ResetPassword from '@/app/features/auth/pages/ResetPassword/ResetPassword';
 
+// no-story: thin Next.js route wrapper; real content is ResetPassword, already storied
 export const metadata: Metadata = {
   title: 'Reset Password — Yosemite Crew',
   description: 'Set a new password for your Yosemite Crew account.',

--- a/apps/frontend/src/app/(routes)/(public)/success/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/success/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 
+// no-story: metadata-only Next.js layout (a bare <main> landmark), no visual content of its own
 export const metadata: Metadata = { title: 'Success — Yosemite Crew' };
 
 type SuccessLayoutProps = Readonly<{

--- a/apps/frontend/src/app/(routes)/(public)/success/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/success/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import React, { Suspense } from 'react';
 import { PaymentStatusContent } from '@/app/(routes)/(public)/payment-status/PaymentStatusContent';
 
+// no-story: thin Next.js route wrapper; real content is PaymentStatusContent, already storied
 export const metadata: Metadata = {
   title: 'Payment Status — Yosemite Crew',
 };

--- a/apps/frontend/src/app/(routes)/(public)/terms-and-conditions/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/terms-and-conditions/page.tsx
@@ -4,6 +4,7 @@ import { MarketingShell } from '@/app/features/marketing/site';
 import TermsAndConditions from '@/app/features/legal/pages/TermsAndConditions';
 import BackToSignup from '@/app/features/legal/components/BackToSignup';
 
+// no-story: thin Next.js route wrapper; real content is TermsAndConditions, already storied
 export const metadata: Metadata = {
   title: 'Terms and conditions · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/trust-center/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/trust-center/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { MarketingShell } from '@/app/features/marketing/site';
 import TrustCenter from '@/app/features/legal/pages/TrustCenter';
 
+// no-story: thin Next.js route wrapper; real content is TrustCenter, already storied
 export const metadata: Metadata = {
   title: 'Security, privacy and compliance · Yosemite Crew',
   description:

--- a/apps/frontend/src/app/(routes)/(public)/verify-email/page.tsx
+++ b/apps/frontend/src/app/(routes)/(public)/verify-email/page.tsx
@@ -3,6 +3,7 @@ import type { Metadata } from 'next';
 
 import VerifyEmail from '@/app/features/auth/pages/VerifyEmail/VerifyEmail';
 
+// no-story: thin Next.js route wrapper; real content is VerifyEmail, already storied
 export const metadata: Metadata = {
   title: 'Verify Email — Yosemite Crew',
   description: 'Verify your Yosemite Crew account email address.',

--- a/apps/frontend/src/app/(routes)/(share)/layout.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/layout.tsx
@@ -24,6 +24,7 @@ import { PRE_PAINT_SCRIPT } from '@/app/ui/theme/prePaintScript';
  * Without it `--ink-faint` stayed at the marketing value #8f8984, which is
  * 3.12:1 on the passport's --screen card at font sizes down to 10.5px.
  */
+// no-story: pure structural wrapper (pre-paint theme script + a display:contents scoping div); no visual content of its own
 export default function ShareLayout({ children }: Readonly<{ children: React.ReactNode }>) {
   return (
     <>

--- a/apps/frontend/src/app/(routes)/(share)/passport/[id]/page.tsx
+++ b/apps/frontend/src/app/(routes)/(share)/passport/[id]/page.tsx
@@ -3,6 +3,7 @@ import { Newsreader } from 'next/font/google';
 import PassportClient from './PassportClient';
 
 // Serif display face for the warm-bone passport surfaces (matches the design).
+// no-story: async server component that only unwraps a route param; real content is PassportClient, already storied
 const newsreader = Newsreader({
   subsets: ['latin'],
   weight: ['400', '500'],

--- a/apps/frontend/src/app/__tests__/noStoryMarkers.test.ts
+++ b/apps/frontend/src/app/__tests__/noStoryMarkers.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * These route/layout/loading files were individually reviewed and marked
+ * `// no-story: <reason>` because each one either has no content of its own
+ * (a metadata-only layout, a structural wrapper) or composes an
+ * already-storied feature component - see the commit that added them for the
+ * per-file reasoning. This test is the thing that keeps that reasoning from
+ * silently rotting: `scripts/ci/story-coverage.mjs`'s NO_STORY_MARKER is what
+ * the gate actually reads to exempt a file, so if a future edit strips the
+ * comment - or moves the file - this fails, rather than the gate quietly
+ * demanding a story for a wrapper that still has none.
+ */
+const MARKED_FILES = [
+  'src/app/(routes)/(app)/appointments/[appointmentId]/workspace/loading.tsx',
+  'src/app/(routes)/(app)/appointments/loading.tsx',
+  'src/app/(routes)/(app)/chat/layout.tsx',
+  'src/app/(routes)/(app)/chat/page.tsx',
+  'src/app/(routes)/(app)/developers/settings/layout.tsx',
+  'src/app/(routes)/(app)/layout.tsx',
+  'src/app/(routes)/(app)/network/page.tsx',
+  'src/app/(routes)/(app)/public-booking-setup/page.tsx',
+  'src/app/(routes)/(book)/layout.tsx',
+  'src/app/(routes)/(public)/about/page.tsx',
+  'src/app/(routes)/(public)/accessibility/page.tsx',
+  'src/app/(routes)/(public)/accessibility/report/layout.tsx',
+  'src/app/(routes)/(public)/accessibility/report/page.tsx',
+  'src/app/(routes)/(public)/auth/callback/page.tsx',
+  'src/app/(routes)/(public)/contact-us/page.tsx',
+  'src/app/(routes)/(public)/developers/page.tsx',
+  'src/app/(routes)/(public)/developers/signin/page.tsx',
+  'src/app/(routes)/(public)/developers/signup/page.tsx',
+  'src/app/(routes)/(public)/dmca/page.tsx',
+  'src/app/(routes)/(public)/impressum/page.tsx',
+  'src/app/(routes)/(public)/insights/page.tsx',
+  'src/app/(routes)/(public)/layout.tsx',
+  'src/app/(routes)/(public)/page.tsx',
+  'src/app/(routes)/(public)/payment-status/layout.tsx',
+  'src/app/(routes)/(public)/payment-status/page.tsx',
+  'src/app/(routes)/(public)/pet-businesses/page.tsx',
+  'src/app/(routes)/(public)/pet-parents/page.tsx',
+  'src/app/(routes)/(public)/pricing/page.tsx',
+  'src/app/(routes)/(public)/privacy-policy/page.tsx',
+  'src/app/(routes)/(public)/reset-password/page.tsx',
+  'src/app/(routes)/(public)/success/layout.tsx',
+  'src/app/(routes)/(public)/success/page.tsx',
+  'src/app/(routes)/(public)/terms-and-conditions/page.tsx',
+  'src/app/(routes)/(public)/trust-center/page.tsx',
+  'src/app/(routes)/(public)/verify-email/page.tsx',
+  'src/app/(routes)/(share)/layout.tsx',
+  'src/app/(routes)/(share)/passport/[id]/page.tsx',
+  'src/app/layout.tsx',
+  'src/app/not-found.tsx',
+];
+
+// Mirrors scripts/ci/story-coverage.mjs's NO_STORY_MARKER exactly - duplicated
+// rather than imported because that script is plain Node ESM outside this
+// workspace's transform root, and the two are locked together by the
+// `matches story-coverage.mjs's own detector` case below, so a drift between
+// them fails loudly here instead of silently at CI time.
+const NO_STORY_MARKER = /\/\/\s*no-story:\s*\S/;
+
+describe('no-story markers on thin route wrappers', () => {
+  it.each(MARKED_FILES)('%s carries a // no-story: marker with a real reason', (relativePath) => {
+    const fullPath = path.join(process.cwd(), relativePath);
+    const content = readFileSync(fullPath, 'utf8');
+    expect(content).toMatch(NO_STORY_MARKER);
+  });
+
+  it("matches story-coverage.mjs's own detector, not a look-alike comment", () => {
+    // The separating case: a comment that mentions "no-story" without the
+    // colon-plus-reason shape the gate requires must NOT satisfy this regex,
+    // or this test would pass on files the real gate still flags as missing.
+    expect('// this component intentionally has no-story yet').not.toMatch(NO_STORY_MARKER);
+    expect('// no-story:').not.toMatch(NO_STORY_MARKER); // no reason after the colon
+    expect('// no-story: thin wrapper, see FooPage').toMatch(NO_STORY_MARKER);
+  });
+});

--- a/apps/frontend/src/app/error.stories.tsx
+++ b/apps/frontend/src/app/error.stories.tsx
@@ -1,0 +1,52 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import GlobalError from './error';
+
+const meta = {
+  title: 'Layout/GlobalError',
+  component: GlobalError,
+  parameters: {
+    layout: 'fullscreen',
+    // The primary action is a next/link, which wants the App Router mock mounted.
+    nextjs: { appDirectory: true },
+    docs: {
+      description: {
+        component:
+          "Next.js's root error boundary (`app/error.tsx`) - what a user sees when an " +
+          'unhandled render error escapes the whole app. Uses the same warm-bone state-card ' +
+          'language as NotFoundState and PermissionDeniedState rather than a generic panel, ' +
+          'and always logs the caught error to the console for diagnosis.',
+      },
+    },
+  },
+  args: {
+    error: Object.assign(new Error('Simulated render error'), { digest: 'story-digest' }),
+    reset: fn(),
+  },
+  tags: ['autodocs'],
+} satisfies Meta<typeof GlobalError>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Something went wrong')).toBeInTheDocument();
+    await expect(
+      canvas.getByText(
+        'An unexpected error occurred. If this keeps happening, please contact support.'
+      )
+    ).toBeInTheDocument();
+
+    await expect(canvas.getByRole('link', { name: 'Go to Dashboard' })).toHaveAttribute(
+      'href',
+      '/dashboard'
+    );
+
+    await expect(args.reset).not.toHaveBeenCalled();
+    await userEvent.click(canvas.getByRole('button', { name: 'Try again' }));
+    await expect(args.reset).toHaveBeenCalledTimes(1);
+  },
+};

--- a/apps/frontend/src/app/layout.tsx
+++ b/apps/frontend/src/app/layout.tsx
@@ -6,6 +6,7 @@ import './globals.css';
 // Warm-bone display serif for page titles + greeting moments. Self-hosted by next/font
 // at build time (served from /_next, so it satisfies the strict app-route CSP), exposed
 // as --font-newsreader-src which the --font-newsreader token consumes (see globals.css).
+// no-story: root Next.js layout - returns a full <html>/<body> document, which cannot mount inside Storybook's own DOM; every component it renders (SkipLink, Cookies, PostHogBootstrap, etc.) is already storied on its own
 const newsreader = Newsreader({
   subsets: ['latin'],
   style: ['normal', 'italic'],

--- a/apps/frontend/src/app/not-found.tsx
+++ b/apps/frontend/src/app/not-found.tsx
@@ -3,6 +3,7 @@ import PublicShell from '@/app/ui/layout/PublicShell';
 import NotFoundState from '@/app/ui/layout/states/NotFoundState';
 import UniversalSearchPalette from '@/app/ui/layout/UniversalSearch/UniversalSearchPalette';
 
+// no-story: thin composition of already-storied pieces (PublicShell, NotFoundState, UniversalSearchPalette)
 export default function NotFound() {
   return (
     <PublicShell>


### PR DESCRIPTION
## What is the current behavior?

The story-coverage gate (`scripts/ci/story-coverage.mjs`) tracks components missing a Storybook story. After fixing the gate's own folder-basename naming blind spot in #3044, a full audit of `apps/frontend`'s current state found 41 genuinely missing stories.

## What is the new behavior?

39 of the 41 are thin Next.js route/layout/loading files under `src/app/`. Each was read individually: every one either has no visual content of its own (a metadata-only layout, a structural redirect) or composes an already-storied feature component (all 20 underlying components confirmed to have a real story via `find`). Marked with `// no-story: <reason>`, naming the already-covered component where relevant.

The 1 real gap is fixed: `app/error.tsx` (the root error boundary) had no story despite being a genuine, self-contained, testable component. Added `error.stories.tsx` following the same convention as the sibling `NotFoundState` story, with a `play` function covering both the reset action and the dashboard link.

`AppointmentWorkspace/index.tsx` (1896 lines, deep store integration across 6 Zustand stores) is the one remaining gap, deliberately deferred as its own dedicated pass rather than a rushed story.

## Verification

- `node scripts/ci/story-coverage.mjs --base <merge-base> --head HEAD --dir apps/frontend`: "every new component has a story"
- Full-codebase re-run of `evaluate()` (using the fixed script from #3044) against all 2149 current `apps/frontend/src/**/*.tsx` files: `checked: 605, missing: 1` — only `AppointmentWorkspace/index.tsx`, matching the deliberate deferral above.
- `tsc --noEmit` and `eslint` clean on every touched file (39 marker files + `error.stories.tsx`).
- `error.stories.tsx`'s assertions were traced by hand against `BaseButton.tsx`'s actual DOM output (`Primary` with no `href` renders `<button>`, `Secondary` with `href` renders next/link's `<a>`) to confirm every `getByRole`/`toHaveAttribute` query matches what really renders — live Storybook verification was blocked by sustained high load on this machine (two independent dev-server attempts stalled with near-zero CPU progress; confirmed via `top`/`uptime`, not app-specific).

## Related Issue(s)

Part of the ongoing Storybook-coverage sweep across web/mobile-responsive/mobile app.