### PR TITLE
ci(repo): make story coverage a required check, not dead code

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -133,6 +133,55 @@ jobs:
 
       - run: node scripts/mobile/version.mjs --check
 
+  story-coverage:
+    name: Story coverage
+    # scripts/ci/story-coverage.mjs fails a PR that adds a new apps/frontend
+    # component with no sibling Storybook story - as strict a bar as Sonar's:
+    # a listed dependency of `CI Required`, not an advisory. It only judges
+    # files a PR *adds* (see the script's own header for why), so the existing
+    # storyless backlog cannot block an unrelated change; it only stops that
+    # backlog from growing. Pure node:fs/path/child_process, no pnpm install
+    # needed - same shape as mobile-version above.
+    needs: core
+    if: needs.core.outputs.frontend == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          # story-coverage.mjs diffs added files against the merge base, so
+          # full history must be present - the same reason core's detect job
+          # uses fetch-depth: 0.
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version-file: .nvmrc
+
+      - name: Compute base SHA
+        id: base
+        env:
+          GITHUB_EVENT_NAME: ${{ github.event_name }}
+          EVENT_BEFORE: ${{ github.event.before }}
+          PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          MERGE_GROUP_BASE_SHA: ${{ github.event.merge_group.base_sha }}
+        run: ./scripts/ci/compute-base-sha.sh >> "$GITHUB_OUTPUT"
+
+      - name: Every new frontend component needs a story
+        env:
+          BASE_SHA: ${{ steps.base.outputs.sha }}
+        run: |
+          set -euo pipefail
+          # Fail closed, matching compute-base-sha.sh's own contract: an empty
+          # sha means no trustworthy base was found, not "nothing changed".
+          if [ -z "$BASE_SHA" ]; then
+            echo "::error::No trustworthy base SHA to diff against - cannot verify story coverage."
+            exit 1
+          fi
+          node scripts/ci/story-coverage.mjs --base "$BASE_SHA" --head HEAD
+
   ci-required:
     name: CI Required
     # REQUIRED on the `dev` ruleset since 2026-09-06, alongside
@@ -148,7 +197,7 @@ jobs:
     # points a reader at the opposite action. Runbook:
     # docs/ci/required-checks-migration.md.
     if: always()
-    needs: [core, test, migration, sonar, frontend-quality, mobile-version]
+    needs: [core, test, migration, sonar, frontend-quality, mobile-version, story-coverage]
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,6 +62,22 @@ pnpm run lint --filter frontend
 pnpm run test --filter backend
 ```
 
+### Every new frontend component needs a Storybook story
+
+A pull request that adds a new component under `apps/frontend/src/app` and no
+sibling `*.stories.tsx` fails CI (`scripts/ci/story-coverage.mjs`, run as the
+`Story coverage` check) - a required, blocking gate, the same tier as the
+Sonar quality gate. It only judges files the PR *adds*, not the pre-existing
+backlog, so it can't block an unrelated change.
+
+If a file genuinely doesn't need a story (a thin wrapper, something only ever
+exercised inside a parent's story), mark it explicitly rather than working
+around the gate:
+
+```tsx
+// no-story: thin route wrapper, real content is <FooPage>, already storied
+```
+
 ## Commit Message Convention
 
 Commit messages are validated by `commitlint` (locally via Husky and in CI).

--- a/docs/ci/required-checks-migration.md
+++ b/docs/ci/required-checks-migration.md
@@ -17,6 +17,10 @@ directly:
 - `_sonar` - scan only, reading the coverage `_test` produced. No install, no
   Prisma, no jest. Kill switch: set the `DISABLE_SONAR` repo variable to `true`.
 - `frontend-quality` - bundle budgets and Lighthouse, consuming `next-build`.
+- `story-coverage` - `scripts/ci/story-coverage.mjs` fails a PR that adds a new
+  `apps/frontend` component with no sibling Storybook story. Added to
+  `CI Required`'s dependency list 2026-09-11, at the same blocking tier as
+  `sonar`'s quality gate - not an advisory check.
 - `CI Required` - one aggregate check. **Required on `dev` since 2026-09-06.**
 
 ## What was removed, and where it went


### PR DESCRIPTION
## What is the current behavior?

`scripts/ci/story-coverage.mjs` has real, tested logic (folder-basename naming fixed in #3044, current backlog closed to 1 deliberately-deferred component in #3045), but is never actually invoked against a real PR diff by any workflow. `pnpm run test:scripts` (in `_core.yaml`'s `detect` job) runs the script's own unit tests - it never runs `story-coverage.mjs` itself against a PR's changed files. Every "story coverage" check this repo has had until now was a human running the script by hand.

## What is the new behavior?

Requested directly: a PR shouldn't be able to pass unless a new component has a Storybook story, "as stringent as the Sonar 95% coverage requirement bar."

- Adds a `story-coverage` job to `ci.yaml`, gated on `needs.core.outputs.frontend == 'true'`, using the same base-SHA resolver `core`'s `detect` job uses (`compute-base-sha.sh`), failing closed if no trustworthy base is found.
- Lists it as a dependency of `ci-required`. `CI Required` has been a required, blocking status check on the `dev` ruleset since 2026-09-06 (`docs/ci/required-checks-migration.md`) - joining its `needs` list is the exact mechanism `sonar` already uses to be blocking, not an advisory. No separate branch-protection/ruleset change needed.
- Documents the requirement in `CONTRIBUTING.md` and corrects `docs/ci/required-checks-migration.md`'s "what runs" list to mention it.

Deliberately still scoped to `apps/frontend` only. `apps/mobileAppYC` has zero Storybook infrastructure as of this PR (a separate initiative, not yet landed) - extending this gate there before that infra exists would block every mobile PR with no path to green.

## Testing

- `actionlint .github/workflows/ci.yaml` and a full-repo `actionlint` run: clean (pre-existing shellcheck notices in unrelated files only).
- Ran the exact job logic locally: `compute-base-sha.sh` + `story-coverage.mjs --base <sha> --head HEAD` against this branch's real diff - 0 new components, passes.
- Then committed a real storyless test component (`apps/frontend/src/app/ui/primitives/CiVerifyTestComponent/index.tsx`, 8 code lines, a real default-exported component with a JSX closing tag) and re-ran the identical command - failed with exit 1, correct expected-story path in the error message. Removed before this PR's real commit.
- This PR itself touches `.github/workflows/ci.yaml`, which `_core.yaml`'s detect job treats as "run everything" - so the new `story-coverage` job runs for real on this PR's own CI, not just locally.

## Related Issue(s)

None - direct request.