### PR TITLE
fix(frontend): reveal a clipped label by tap, not only by hover

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PackageBreakdownTooltip.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/PackageBreakdownTooltip.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+import PackageBreakdownTooltip from '@/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip';
+import type { InvoiceLineItem } from '@/app/features/appointments/types/workspace';
+
+const PACKAGE_ITEM: InvoiceLineItem = {
+  id: 'line-dental-package',
+  name: 'Dental package (grade 2)',
+  unitPriceCents: 38360,
+  qty: 1,
+  grossCents: 38360,
+  discountCents: 3836,
+  amountCents: 34524,
+  breakdown: [
+    {
+      id: 'cmp-1',
+      name: 'General anaesthesia (first 30 min)',
+      qty: 1,
+      instructions: 'Procedure',
+      unitPriceCents: 12000,
+      amountCents: 12000,
+    },
+  ],
+};
+
+describe('PackageBreakdownTooltip', () => {
+  it('opens the breakdown by tap, with no hover involved', async () => {
+    render(<PackageBreakdownTooltip item={PACKAGE_ITEM} currency="USD" />);
+
+    const trigger = screen.getByRole('button', {
+      name: 'View Dental package (grade 2) package breakdown',
+    });
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toBeInTheDocument();
+    });
+    expect(screen.getByText('General anaesthesia (first 30 min)')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SummaryStep.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/AppointmentWorkspace/SummaryStep.test.tsx
@@ -217,6 +217,29 @@ describe('SummaryStep', () => {
     expect(listEncounterWorkspaceDocuments).toHaveBeenCalledWith('org-1', 'enc-1');
   });
 
+  it('reveals a clipped document title by tap, not only by hover', async () => {
+    const longTitle =
+      'Discharge summary and post-operative medication plan for a lengthy hospital stay';
+    (listEncounterWorkspaceDocuments as jest.Mock).mockResolvedValue([
+      makeDocumentRow({ title: longTitle }),
+    ]);
+    const enc = seedAndGet();
+    await act(async () => {
+      render(<SummaryStep appointmentId={APPT} appointment={appointment} encounter={enc} />);
+    });
+
+    const titleSpan = await screen.findByText(longTitle);
+    expect(titleSpan).toHaveClass('truncate');
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+
+    // A mouse hover is not available on a touchscreen - a tap on the
+    // truncated label itself must be enough to read the full value.
+    fireEvent.click(titleSpan.closest('.glass-tooltip') as HTMLElement);
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent(longTitle);
+    });
+  });
+
   it('places the follow-up date field after the discharge editor', () => {
     const enc = seedAndGet();
     renderSummary(enc);

--- a/apps/frontend/src/app/__tests__/ui/primitives/GlassTooltip.test.tsx
+++ b/apps/frontend/src/app/__tests__/ui/primitives/GlassTooltip.test.tsx
@@ -34,6 +34,50 @@ describe('GlassTooltip', () => {
     });
   });
 
+  it('does not open on click when openOnClick is unset', async () => {
+    render(
+      <GlassTooltip content="Hello tooltip">
+        <button type="button">Trigger</button>
+      </GlassTooltip>
+    );
+
+    const trigger = screen.getByText('Trigger').closest('span') as HTMLElement;
+    fireEvent.click(trigger);
+    expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+  });
+
+  it('opens on tap and stays open on a second tap, closing only outside the trigger', async () => {
+    render(
+      <div>
+        <GlassTooltip content="Full value" openOnClick>
+          <button type="button">Info</button>
+        </GlassTooltip>
+        <button type="button">Elsewhere</button>
+      </div>
+    );
+
+    const trigger = screen.getByText('Info').closest('span') as HTMLElement;
+    Object.defineProperty(trigger, 'getBoundingClientRect', {
+      configurable: true,
+      value: () => ({ top: 100, left: 100, right: 160, bottom: 140, width: 60, height: 40 }),
+    });
+
+    fireEvent.click(trigger);
+    await waitFor(() => {
+      expect(screen.getByRole('tooltip')).toHaveTextContent('Full value');
+    });
+
+    // A no-op mouse leave never touched this path (openOnClick has no hover
+    // listener of its own), and a second tap must not toggle it back closed.
+    fireEvent.click(trigger);
+    expect(screen.getByRole('tooltip')).toBeInTheDocument();
+
+    fireEvent.mouseDown(screen.getByText('Elsewhere'));
+    await waitFor(() => {
+      expect(screen.queryByRole('tooltip')).not.toBeInTheDocument();
+    });
+  });
+
   it('applies side-specific transform style', async () => {
     render(
       <GlassTooltip content="Right side" side="right">

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.stories.tsx
@@ -261,6 +261,31 @@ export const KeyboardFocus: Story = {
   },
 };
 
+export const OpenedByTap: Story = {
+  name: 'Opened by tap (touch)',
+  play: async ({ canvasElement }) => {
+    // Hover and focus have no touch equivalent, so this trigger has
+    // `openOnClick` - the same dispatch-until-listening pattern as the hover
+    // and focus stories, via a plain click instead.
+    const bubble = await openGlassTooltip(
+      within(canvasElement).getByRole('button', {
+        name: `View ${PACKAGE_ITEM.name} package breakdown`,
+      }),
+      { via: 'click' }
+    );
+    await expect(within(bubble).getAllByRole('columnheader')).toHaveLength(7);
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The one interaction the other stories never exercised: a tap, with no hover or ' +
+          'keyboard focus involved.',
+      },
+    },
+  },
+};
+
 export const NoBreakdown: Story = {
   name: 'Not a package (renders nothing)',
   args: {

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/components/PackageBreakdownTooltip.tsx
@@ -31,6 +31,7 @@ const PackageBreakdownTooltip = ({ item, currency }: PackageBreakdownTooltipProp
 
   return (
     <GlassTooltip
+      openOnClick
       content={
         <div className="flex min-w-130 flex-col gap-3 text-left">
           <div className="flex flex-col gap-0.5">

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/SummaryStep.tsx
@@ -284,9 +284,11 @@ export const AllDocumentsTable = ({
                 className="flex items-start gap-3 rounded-2xl border border-card-border p-4"
               >
                 <div className="flex min-w-0 flex-1 flex-col gap-2">
-                  <span className="truncate font-medium text-text-primary" title={document.title}>
-                    {document.title}
-                  </span>
+                  <GlassTooltip content={document.title} openOnClick className="w-full min-w-0">
+                    <span className="block truncate font-medium text-text-primary">
+                      {document.title}
+                    </span>
+                  </GlassTooltip>
                   <div className="flex flex-wrap items-center gap-2">
                     <DocumentSourcePill source={document.sourceKind} />
                     <span className="text-body-4 text-text-primary">

--- a/apps/frontend/src/app/ui/primitives/GlassTooltip/GlassTooltip.stories.tsx
+++ b/apps/frontend/src/app/ui/primitives/GlassTooltip/GlassTooltip.stories.tsx
@@ -23,7 +23,11 @@ const meta = {
           'exercised by rendering a button. The stories now open the bubble in a `play` function, ' +
           'so the placement logic is under visual review.\n\n' +
           'Both entry paths are covered: hover, and keyboard focus via `focusin`, which is the one ' +
-          'a keyboard user actually gets.',
+          'a keyboard user actually gets.\n\n' +
+          '`openOnClick` adds a third: tap opens, and a tap outside the trigger or the bubble ' +
+          'closes it. Off by default because a trigger that already does something on click ' +
+          '(navigate, submit) would have that first tap consumed by the tooltip instead - only ' +
+          'set it on a trigger whose sole purpose is revealing `content`.',
       },
     },
   },
@@ -146,6 +150,25 @@ export const LongContent: Story = {
           'can never show.',
       },
     },
+  },
+};
+
+export const OpenOnClick: Story = {
+  name: 'Opened by tap (touch)',
+  args: { side: 'top', content: 'Reachable without hover', openOnClick: true },
+  render: (args) => (
+    <GlassTooltip {...args}>
+      <TriggerButton>Tap me</TriggerButton>
+    </GlassTooltip>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    // Same dispatch-until-listening pattern as openOnHover: the click listener
+    // is bound in an effect that may not have flushed when play starts.
+    const bubble = await openGlassTooltip(canvas.getByRole('button', { name: 'Tap me' }), {
+      via: 'click',
+    });
+    await expect(bubble).toHaveTextContent('Reachable without hover');
   },
 };
 

--- a/apps/frontend/src/app/ui/primitives/GlassTooltip/GlassTooltip.tsx
+++ b/apps/frontend/src/app/ui/primitives/GlassTooltip/GlassTooltip.tsx
@@ -10,6 +10,13 @@ type GlassTooltipProps = {
   side?: TooltipSide;
   className?: string;
   maxWidth?: number | string;
+  /** Also toggle open on tap. Hover and focus have no touch equivalent, so a
+   * trigger whose only affordance is `content` (e.g. the full value behind a
+   * truncated label) is otherwise unreachable on a touchscreen. Off by
+   * default: a trigger with its own click behavior (navigation, a button
+   * action) would have that first tap swallowed by the tooltip opening
+   * instead - review each call site before opting in. */
+  openOnClick?: boolean;
 };
 
 const GlassTooltip = ({
@@ -18,6 +25,7 @@ const GlassTooltip = ({
   side = 'top',
   className = '',
   maxWidth,
+  openOnClick = false,
 }: GlassTooltipProps) => {
   const triggerRef = useRef<HTMLDivElement | null>(null);
   const bubbleRef = useRef<HTMLDivElement | null>(null);
@@ -118,6 +126,38 @@ const GlassTooltip = ({
       trigger.removeEventListener('focusout', closeTooltip);
     };
   }, []);
+
+  useEffect(() => {
+    if (!openOnClick) return undefined;
+    const trigger = triggerRef.current;
+    if (!trigger) return undefined;
+
+    // Idempotent open, not a toggle: a toggle would also have to survive a
+    // Storybook play function that retries the dispatch until the listener
+    // is bound (see storyInteractions.ts), where a second, redundant dispatch
+    // would close what the first one just opened.
+    const openTooltip = (event: MouseEvent) => {
+      event.stopPropagation();
+      setOpen(true);
+    };
+    trigger.addEventListener('click', openTooltip);
+    return () => trigger.removeEventListener('click', openTooltip);
+  }, [openOnClick]);
+
+  useEffect(() => {
+    if (!openOnClick || !open) return undefined;
+    const closeOnOutside = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      if (triggerRef.current?.contains(target) || bubbleRef.current?.contains(target)) return;
+      setOpen(false);
+    };
+    document.addEventListener('mousedown', closeOnOutside, { passive: true });
+    document.addEventListener('touchstart', closeOnOutside, { passive: true });
+    return () => {
+      document.removeEventListener('mousedown', closeOnOutside);
+      document.removeEventListener('touchstart', closeOnOutside);
+    };
+  }, [openOnClick, open]);
 
   return (
     <span ref={triggerRef} className={`glass-tooltip relative inline-flex ${className}`}>

--- a/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
+++ b/apps/frontend/src/app/ui/primitives/GlassTooltip/storyInteractions.ts
@@ -58,13 +58,14 @@ const bubbles = () => [...document.querySelectorAll('[role="tooltip"]')] as HTML
  */
 export const openGlassTooltip = async (
   trigger: HTMLElement,
-  { via = 'hover' }: { via?: 'hover' | 'focus' } = {}
+  { via = 'hover' }: { via?: 'hover' | 'focus' | 'click' } = {}
 ): Promise<HTMLElement> => {
   const wrapper = glassTooltipWrapper(trigger);
-  const event = () =>
-    via === 'hover'
-      ? new MouseEvent('mouseenter', { bubbles: false })
-      : new FocusEvent('focusin', { bubbles: true });
+  const event = () => {
+    if (via === 'hover') return new MouseEvent('mouseenter', { bubbles: false });
+    if (via === 'click') return new MouseEvent('click', { bubbles: true });
+    return new FocusEvent('focusin', { bubbles: true });
+  };
 
   // Anything already open belongs to someone else and can never count as success.
   const stale = new Set(bubbles());


### PR DESCRIPTION
## Summary
- Mobile-viewport (375px) Storybook sweep (365 hits / 105 components) found the `GlassTooltip` primitive has no touch affordance at all — every consumer whose only way to reveal content is a mouse (hover) or keyboard (focus) is unreachable on a touchscreen.
- Adds an opt-in `openOnClick` prop to `GlassTooltip` (off by default: a trigger with its own click behavior would have that first tap swallowed by the tooltip opening instead).
- Turns it on for the two sites confirmed safe by this pass: the document title in `AllDocumentsTable` (native `title` attribute only, no touch equivalent), and the package-breakdown info button in `PackageBreakdownTooltip` (icon-only trigger, no competing click handler).

## Test plan
- [x] `GlassTooltip.test.tsx`: new tests for open-on-tap, no-op when `openOnClick` unset, and close-on-outside-tap; mutation-checked (breaking `openOnClick` fails the new tests)
- [x] `SummaryStep.test.tsx`: new test taps a clipped document title and asserts the full value appears; mutation-checked (reverting the fix fails the test)
- [x] `PackageBreakdownTooltip.test.tsx` (new file): taps the info button with no hover involved; mutation-checked
- [x] `tsc --noEmit` clean, `eslint` clean on all changed files
- [x] Full targeted suite green post-rebase onto `dev` (86 tests, 5 suites)
- [x] `story-coverage.mjs --files` passes (no new components added)