### PR TITLE
feat(frontend): intake-form draft-import review UI (#3060)

### DIFF
--- a/apps/frontend/src/app/(routes)/(app)/developers/(portal)/form-draft-import/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/developers/(portal)/form-draft-import/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from 'next';
+import React from 'react';
+
+import DeveloperFormDraftImport from '@/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport';
+
+export const metadata: Metadata = { title: 'Form draft import — Yosemite Crew' };
+
+function Page() {
+  return <DeveloperFormDraftImport />;
+}
+
+export default Page;

--- a/apps/frontend/src/app/__tests__/pages/DeveloperFormDraftImport.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperFormDraftImport.test.tsx
@@ -1,0 +1,218 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock('@/app/services/formDraftImportService', () => ({
+  createDraftImport: jest.fn(),
+  getDraftImport: jest.fn(),
+  discardDraftImport: jest.fn(),
+}));
+
+jest.mock('@/app/features/forms/services/formService', () => ({
+  loadForms: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="dev-guard">{children}</div>
+  ),
+}));
+
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  __esModule: true,
+  Primary: ({ text, onClick, type, isDisabled }: any) => (
+    <button type={type ?? 'button'} onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/ui/inputs/Dropdown/LabelDropdown', () => ({
+  __esModule: true,
+  default: ({ options, onSelect }: any) => (
+    <div>
+      {options.map((option: any) => (
+        <button key={option.value} type="button" onClick={() => onSelect(option)}>
+          Choose {option.label}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import DeveloperFormDraftImport from '@/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport';
+import {
+  createDraftImport,
+  discardDraftImport,
+  getDraftImport,
+} from '@/app/services/formDraftImportService';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+
+const createDraftImportMock = createDraftImport as jest.Mock;
+const getDraftImportMock = getDraftImport as jest.Mock;
+const discardDraftImportMock = discardDraftImport as jest.Mock;
+
+const VIEW = {
+  id: 'd1',
+  organisationId: 'org1',
+  sourceFormId: 'form1',
+  draftFormId: 'draftForm1',
+  suppliedText: 'Patient name | input | required',
+  fields: [
+    { id: 'patient-name', type: 'input', label: 'Patient name', required: true, sourceLine: 1 },
+  ],
+  unsupportedConstructs: [{ line: 2, raw: 'Signature | inkblot', reason: 'Unknown type' }],
+  diff: [
+    {
+      id: 'patient-name',
+      change: 'added',
+      after: { type: 'input', label: 'Patient name', required: true },
+    },
+  ],
+  stale: false,
+  createdAt: '2026-09-12T00:00:00.000Z',
+  updatedAt: '2026-09-12T00:00:00.000Z',
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useOrgStore.setState({ primaryOrgId: 'org1' });
+  useFormsStore.setState({
+    formsById: {
+      form1: {
+        _id: 'form1',
+        name: 'Consent form',
+        category: 'Consent form',
+        usage: 'Standalone' as any,
+        updatedBy: 'u1',
+        lastUpdated: '2026-09-01T00:00:00.000Z',
+        status: 'Published',
+        schema: [],
+      } as any,
+    },
+    formIds: ['form1'],
+  });
+});
+
+describe('DeveloperFormDraftImport page', () => {
+  it('shows the import form before anything is submitted', () => {
+    render(<DeveloperFormDraftImport />);
+    expect(screen.getByLabelText(/Supplied form text/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Preview import' })).toBeDisabled();
+  });
+
+  it('only offers published forms as a diff source', () => {
+    useFormsStore.setState({
+      formsById: {
+        form1: { ...useFormsStore.getState().formsById.form1 },
+        draft1: {
+          _id: 'draft1',
+          name: 'Unpublished form',
+          category: 'Consent form',
+          usage: 'Standalone' as any,
+          updatedBy: 'u1',
+          lastUpdated: '2026-09-01T00:00:00.000Z',
+          status: 'Draft',
+          schema: [],
+        } as any,
+      },
+      formIds: ['form1', 'draft1'],
+    });
+    render(<DeveloperFormDraftImport />);
+    expect(screen.getByRole('button', { name: 'Choose Consent form' })).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Choose Unpublished form' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('submits the supplied text and renders the review', async () => {
+    const user = userEvent.setup();
+    createDraftImportMock.mockResolvedValue(VIEW);
+    render(<DeveloperFormDraftImport />);
+
+    await user.click(screen.getByRole('button', { name: 'Choose Consent form' }));
+    await user.type(screen.getByLabelText(/Supplied form text/), 'Patient name | input | required');
+    await user.click(screen.getByRole('button', { name: 'Preview import' }));
+
+    expect(await screen.findByText('Proposed fields (1)')).toBeInTheDocument();
+    expect(createDraftImportMock).toHaveBeenCalledWith('org1', {
+      suppliedText: 'Patient name | input | required',
+      sourceFormId: 'form1',
+    });
+    expect(screen.getByText('Unsupported constructs (1)')).toBeInTheDocument();
+    expect(screen.getByText('Signature | inkblot')).toBeInTheDocument();
+    expect(screen.getByTestId('diff-patient-name')).toHaveTextContent('Added');
+  });
+
+  it('shows an error when the import fails', async () => {
+    const user = userEvent.setup();
+    createDraftImportMock.mockRejectedValue(new Error('boom'));
+    render(<DeveloperFormDraftImport />);
+
+    await user.type(screen.getByLabelText(/Supplied form text/), 'x | input');
+    await user.click(screen.getByRole('button', { name: 'Preview import' }));
+
+    expect(await screen.findByText(/Could not import the supplied text/)).toBeInTheDocument();
+  });
+
+  it('refreshes a stale draft', async () => {
+    const user = userEvent.setup();
+    createDraftImportMock.mockResolvedValue({ ...VIEW, stale: true });
+    getDraftImportMock.mockResolvedValue({ ...VIEW, stale: false });
+    render(<DeveloperFormDraftImport />);
+
+    await user.type(screen.getByLabelText(/Supplied form text/), 'x | input');
+    await user.click(screen.getByRole('button', { name: 'Preview import' }));
+    await screen.findByText(/source form changed/);
+
+    await user.click(screen.getByRole('button', { name: 'Refresh' }));
+    expect(getDraftImportMock).toHaveBeenCalledWith('org1', 'd1');
+    await waitFor(() => expect(screen.queryByText(/source form changed/)).not.toBeInTheDocument());
+  });
+
+  it('discards the draft and returns to the form', async () => {
+    const user = userEvent.setup();
+    createDraftImportMock.mockResolvedValue(VIEW);
+    discardDraftImportMock.mockResolvedValue(undefined);
+    render(<DeveloperFormDraftImport />);
+
+    await user.type(screen.getByLabelText(/Supplied form text/), 'x | input');
+    await user.click(screen.getByRole('button', { name: 'Preview import' }));
+    await screen.findByText('Proposed fields (1)');
+
+    await user.click(screen.getByRole('button', { name: 'Discard draft' }));
+    expect(discardDraftImportMock).toHaveBeenCalledWith('org1', 'd1');
+    await waitFor(() => expect(screen.getByLabelText(/Supplied form text/)).toBeInTheDocument());
+  });
+
+  it('shows the 409 message when discard fails because it was already published', async () => {
+    const user = userEvent.setup();
+    createDraftImportMock.mockResolvedValue(VIEW);
+    discardDraftImportMock.mockRejectedValue(new Error('already published'));
+    render(<DeveloperFormDraftImport />);
+
+    await user.type(screen.getByLabelText(/Supplied form text/), 'x | input');
+    await user.click(screen.getByRole('button', { name: 'Preview import' }));
+    await screen.findByText('Proposed fields (1)');
+
+    await user.click(screen.getByRole('button', { name: 'Discard draft' }));
+    expect(await screen.findByText(/already have been published/)).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/services/formDraftImportService.test.ts
+++ b/apps/frontend/src/app/__tests__/services/formDraftImportService.test.ts
@@ -1,0 +1,62 @@
+import {
+  createDraftImport,
+  discardDraftImport,
+  getDraftImport,
+} from '@/app/services/formDraftImportService';
+import { getData, postData, deleteData } from '@/app/services/axios';
+
+jest.mock('@/app/services/axios', () => ({
+  getData: jest.fn(),
+  postData: jest.fn(),
+  deleteData: jest.fn(),
+}));
+
+const getDataMock = getData as jest.Mock;
+const postDataMock = postData as jest.Mock;
+const deleteDataMock = deleteData as jest.Mock;
+
+const VIEW = {
+  id: 'd1',
+  organisationId: 'org1',
+  sourceFormId: null,
+  draftFormId: 'f1',
+  suppliedText: 'Patient name | input | required',
+  fields: [],
+  unsupportedConstructs: [],
+  diff: [],
+  stale: false,
+  createdAt: '2026-09-12T00:00:00.000Z',
+  updatedAt: '2026-09-12T00:00:00.000Z',
+};
+
+describe('formDraftImportService', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  describe('createDraftImport', () => {
+    it('posts to the org-scoped endpoint and unwraps the envelope', async () => {
+      postDataMock.mockResolvedValue({ data: { data: VIEW } });
+      const result = await createDraftImport('org1', { suppliedText: 'x' });
+      expect(postDataMock).toHaveBeenCalledWith('/v1/form-draft-imports/org1', {
+        suppliedText: 'x',
+      });
+      expect(result).toEqual(VIEW);
+    });
+  });
+
+  describe('getDraftImport', () => {
+    it('gets by org and id and unwraps the envelope', async () => {
+      getDataMock.mockResolvedValue({ data: { data: VIEW } });
+      const result = await getDraftImport('org1', 'd1');
+      expect(getDataMock).toHaveBeenCalledWith('/v1/form-draft-imports/org1/d1');
+      expect(result).toEqual(VIEW);
+    });
+  });
+
+  describe('discardDraftImport', () => {
+    it('deletes by org and id', async () => {
+      deleteDataMock.mockResolvedValue({});
+      await discardDraftImport('org1', 'd1');
+      expect(deleteDataMock).toHaveBeenCalledWith('/v1/form-draft-imports/org1/d1');
+    });
+  });
+});

--- a/apps/frontend/src/app/constants/routes.ts
+++ b/apps/frontend/src/app/constants/routes.ts
@@ -81,6 +81,12 @@ export const appRoutes: RouteItem[] = [
 export const devRoutes: RouteItem[] = [
   { name: 'Dashboard', href: '/developers/home' },
   { name: 'API Keys', href: '/developers/api-keys' },
+  {
+    name: 'Form Draft Import',
+    href: '/developers/form-draft-import',
+    verify: true,
+    requiredAnyPermissions: [PERMISSIONS.FORMS_VIEW_ANY],
+  },
   { name: 'Billing', href: '/developers/billing' },
   { name: 'Website - Builder', href: '/developers/website-builder' },
   { name: 'Plugins', href: '/developers/plugins' },

--- a/apps/frontend/src/app/features/developers/index.ts
+++ b/apps/frontend/src/app/features/developers/index.ts
@@ -1,6 +1,7 @@
 export { default as DeveloperDocs } from '@/app/features/developers/pages/DeveloperDocs/DeveloperDocs';
 export { default as DeveloperPortalHome } from '@/app/features/developers/pages/DeveloperPortalHome/DeveloperPortalHome';
 export { default as DeveloperApiKeys } from '@/app/features/developers/pages/DeveloperApiKeys/DeveloperApiKeys';
+export { default as DeveloperFormDraftImport } from '@/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport';
 export { default as DeveloperSettings } from '@/app/features/developers/pages/DeveloperSettings/DeveloperSettings';
 export { default as DeveloperPlugins } from '@/app/features/developers/pages/DeveloperPlugins/DeveloperPlugins';
 export { default as DeveloperWebsiteBuilder } from '@/app/features/developers/pages/DeveloperWebsiteBuilder/DeveloperWebsiteBuilder';

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport.css
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport.css
@@ -1,0 +1,158 @@
+/**
+ * Intake-form draft-import review (#3060). Follows the same card/badge
+ * vocabulary as DeveloperApiKeys.css - real tokens, not grey/white fallback
+ * literals, so it stays in step with the rest of the developer portal.
+ *
+ * The card frame itself (background/border/radius/shadow) is not
+ * re-declared here - it comes from the shared `.yc-card-surface` class in
+ * globals.css (see app/__tests__/ui/tokens/cardSurface.test.ts), which this
+ * file's own classes only add layout to.
+ */
+
+.DraftImport-intro {
+  margin: 8px 0 24px;
+  max-width: 640px;
+}
+
+.DraftImport-error {
+  margin-bottom: 16px;
+  color: var(--color-text-error);
+}
+
+/* Form ---------------------------------------------------------------------- */
+
+.DraftImport-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 640px;
+  margin-bottom: 24px;
+  padding: 20px 22px;
+}
+
+.DraftImport-textarea {
+  width: 100%;
+  box-sizing: border-box;
+  font-family: ui-monospace, 'SF Mono', Menlo, monospace;
+  font-size: 13.5px;
+}
+
+.DraftImport-formActions {
+  display: flex;
+  gap: 12px;
+  margin-top: 8px;
+}
+
+/* Review ---------------------------------------------------------------------- */
+
+.DraftImport-review {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 720px;
+}
+
+.DraftImport-stale {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 18px;
+  background: var(--color-inset);
+  border: 1px solid var(--divider);
+  border-radius: 14px;
+}
+
+.DraftImport-section {
+  padding: 18px 20px;
+}
+
+.DraftImport-unsupportedList,
+.DraftImport-fieldList,
+.DraftImport-diffList {
+  list-style: none;
+  margin: 12px 0 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.DraftImport-unsupportedList li {
+  padding: 10px 12px;
+  background: var(--danger-bg);
+  border: 1px solid var(--danger-border);
+  border-radius: 10px;
+}
+
+.DraftImport-unsupportedLine {
+  font-weight: 700;
+  color: var(--color-text-secondary);
+}
+
+.DraftImport-fieldList li,
+.DraftImport-diffList li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.DraftImport-fieldLabel {
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.DraftImport-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.DraftImport-badge--type {
+  background: var(--color-inset);
+  color: var(--color-text-secondary);
+  border-color: var(--divider);
+}
+
+.DraftImport-badge--required {
+  background: var(--status-completed-bg);
+  color: var(--status-completed-text);
+  border-color: var(--status-completed-border);
+}
+
+.DraftImport-badge--added {
+  background: var(--status-completed-bg);
+  color: var(--status-completed-text);
+  border-color: var(--status-completed-border);
+}
+
+.DraftImport-badge--removed {
+  background: var(--danger-bg);
+  color: var(--danger-text);
+  border-color: var(--danger-border);
+}
+
+.DraftImport-badge--changed {
+  background: var(--color-inset);
+  color: var(--color-text-secondary);
+  border-color: var(--divider);
+}
+
+.DraftImport-badge--unchanged {
+  background: transparent;
+  color: var(--color-text-tertiary);
+  border-color: var(--divider);
+}
+
+.DraftImport-reviewActions {
+  display: flex;
+  gap: 12px;
+}

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport.stories.tsx
@@ -1,0 +1,211 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import type { AxiosResponse, InternalAxiosRequestConfig } from 'axios';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import type { DraftImportView } from '@/app/services/formDraftImportService';
+import DeveloperFormDraftImport from './DeveloperFormDraftImport';
+
+/**
+ * Drives the real component against the real service layer, only the axios
+ * ADAPTER is swapped - same shape as DeveloperApiKeys.stories.tsx, and for the
+ * same reason: stubbing the service module would hide a change to the request
+ * shape or the `{ data }` envelope.
+ *
+ * The forms-loading side effect (source-form dropdown options) is left to
+ * resolve to an empty list here rather than faked through the FHIR
+ * questionnaire mapping it would otherwise require - that path is exercised
+ * for real in DraftImportForm.stories.tsx and the page's own jest test, which
+ * seed the forms store directly.
+ */
+type Handler = (config: InternalAxiosRequestConfig) => { status?: number; body?: unknown };
+
+const stubApi = (handler: Handler) => {
+  const previous = api.defaults.adapter;
+  api.defaults.adapter = async (config) => {
+    const { status = 200, body = [] } = handler(config);
+    if (status >= 400) {
+      throw Object.assign(new Error(`Request failed with status ${status}`), {
+        response: { status, data: body, config },
+        config,
+      });
+    }
+    return { data: body, status, statusText: 'OK', headers: {}, config } as AxiosResponse;
+  };
+  return () => {
+    api.defaults.adapter = previous;
+  };
+};
+
+const ORG_ID = 'org-storybook';
+
+const OWNER_MEMBERSHIP: UserOrganization = {
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+};
+
+const seedStores = () => {
+  const authSnapshot = useAuthStore.getState();
+  const orgSnapshot = useOrgStore.getState();
+
+  useAuthStore.setState({
+    status: 'authenticated',
+    role: 'developer',
+    user: {
+      userId: 'dev-storybook',
+      email: 'ravi@example.test',
+      authProfile: null,
+      loginMethod: 'emailpassword',
+      emailVerified: true,
+      getUsername: () => 'dev-storybook',
+    },
+    attributes: { sub: 'dev-storybook', email: 'ravi@example.test', email_verified: 'true' },
+  });
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: OWNER_MEMBERSHIP },
+    status: 'loaded',
+  });
+
+  return () => {
+    useAuthStore.setState(authSnapshot);
+    useOrgStore.setState(orgSnapshot);
+  };
+};
+
+const setup = (handler: Handler) => () => {
+  clearInFlightGetRequests();
+  const restoreStores = seedStores();
+  const restoreApi = stubApi(handler);
+  return () => {
+    restoreApi();
+    restoreStores();
+    clearInFlightGetRequests();
+  };
+};
+
+const VIEW: DraftImportView = {
+  id: 'd1',
+  organisationId: ORG_ID,
+  sourceFormId: null,
+  draftFormId: 'draft-form-1',
+  suppliedText: 'Patient name | input | required\nConsent to treatment | boolean | required',
+  fields: [
+    { id: 'patient-name', type: 'input', label: 'Patient name', required: true, sourceLine: 1 },
+    {
+      id: 'consent-to-treatment',
+      type: 'boolean',
+      label: 'Consent to treatment',
+      required: true,
+      sourceLine: 2,
+    },
+  ],
+  unsupportedConstructs: [],
+  diff: [],
+  stale: false,
+  createdAt: '2026-09-12T00:00:00.000Z',
+  updatedAt: '2026-09-12T00:00:00.000Z',
+};
+
+const meta = {
+  title: 'Developers/DeveloperFormDraftImport',
+  component: DeveloperFormDraftImport,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/developers/form-draft-import' },
+    },
+    docs: {
+      description: {
+        component:
+          "Review surface for #3055's deterministic supplied-text-to-draft-form import: paste " +
+          'text, preview the proposed fields and the diff against an existing form, then keep ' +
+          '(via the existing form editor/publish flow, untouched here) or discard.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: setup(() => ({ body: [] })),
+} satisfies Meta<typeof DeveloperFormDraftImport>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const CreateAndReview: Story = {
+  name: 'Paste text, preview the draft',
+  beforeEach: setup((config) => {
+    if (config.method?.toLowerCase() === 'post') {
+      return { status: 201, body: { data: VIEW } };
+    }
+    return { body: [] };
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.type(
+      await canvas.findByLabelText(/Supplied form text/),
+      'Patient name | input | required\nConsent to treatment | boolean | required'
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'Preview import' }));
+
+    await waitFor(() => expect(canvas.getByText('Proposed fields (2)')).toBeInTheDocument());
+    await expect(canvas.getByText('Patient name')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Discard draft' })).toBeInTheDocument();
+  },
+};
+
+export const ImportFailed: Story = {
+  name: 'Import request fails',
+  beforeEach: setup((config) => {
+    if (config.method?.toLowerCase() === 'post') {
+      return { status: 400, body: { message: 'No supported fields were found in suppliedText' } };
+    }
+    return { body: [] };
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(await canvas.findByLabelText(/Supplied form text/), 'not a real field');
+    await userEvent.click(canvas.getByRole('button', { name: 'Preview import' }));
+    await waitFor(() =>
+      expect(canvas.getByText(/Could not import the supplied text/)).toBeInTheDocument()
+    );
+  },
+};
+
+export const DiscardAlreadyPublished: Story = {
+  name: 'Discard refused - already published',
+  beforeEach: setup((config) => {
+    if (config.method?.toLowerCase() === 'post') return { status: 201, body: { data: VIEW } };
+    if (config.method?.toLowerCase() === 'delete') {
+      return {
+        status: 409,
+        body: {
+          message: 'This draft has already been published and can no longer be discarded here',
+        },
+      };
+    }
+    return { body: [] };
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(
+      await canvas.findByLabelText(/Supplied form text/),
+      'Patient name | input | required'
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'Preview import' }));
+    await canvas.findByText('Proposed fields (2)');
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Discard draft' }));
+    await waitFor(() =>
+      expect(canvas.getByText(/already have been published/)).toBeInTheDocument()
+    );
+  },
+};

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DeveloperFormDraftImport.tsx
@@ -1,0 +1,158 @@
+'use client';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+
+import DevRouteGuard from '@/app/ui/layout/guards/DevRouteGuard/DevRouteGuard';
+import PermissionGate from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { logger } from '@/app/lib/logger';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { useFormsStore } from '@/app/stores/formsStore';
+import { loadForms } from '@/app/features/forms/services/formService';
+import {
+  createDraftImport,
+  discardDraftImport,
+  getDraftImport,
+  type DraftImportView,
+} from '@/app/services/formDraftImportService';
+
+import DraftImportForm, { type DraftImportFormInput } from './DraftImportForm';
+import DraftImportReview from './DraftImportReview';
+
+import './DeveloperFormDraftImport.css';
+import '@/app/features/organizations/styles/Organizations.css';
+
+/**
+ * Review surface for #3055's deterministic supplied-text-to-draft-form
+ * import: paste text, preview the proposed fields and the diff against an
+ * existing form, then keep (via the existing form editor/publish flow,
+ * untouched here) or discard.
+ *
+ * Owns the data and the three requests (create/refresh/discard); the form and
+ * the review are separate presentational components, same split as
+ * DeveloperApiKeys/CreateKeyForm/KeyTable.
+ */
+const DeveloperFormDraftImport = () => {
+  const primaryOrgId = useOrgStore((state) => state.primaryOrgId);
+  const formIds = useFormsStore((state) => state.formIds);
+  const formsById = useFormsStore((state) => state.formsById);
+  const forms = useMemo(() => formIds.map((id) => formsById[id]), [formIds, formsById]);
+
+  const [view, setView] = useState<DraftImportView | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [discarding, setDiscarding] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    loadForms().catch((err) => logger.error('Failed to load forms for draft import', err));
+  }, []);
+
+  // Only a form with a real backend id and a published version is a usable
+  // diff base; the backend's loadSourceForm looks up Form.id directly and a
+  // 404 there would otherwise read as an inexplicable error on submit.
+  const sourceOptions = useMemo(
+    () =>
+      forms
+        .filter((form) => Boolean(form._id) && form.status === 'Published')
+        .map((form) => ({ value: form._id as string, label: form.name })),
+    [forms]
+  );
+
+  const handleSubmit = async (input: DraftImportFormInput) => {
+    if (!primaryOrgId) {
+      setError('No organisation selected.');
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await createDraftImport(primaryOrgId, input);
+      setView(created);
+    } catch (err) {
+      logger.error('Failed to create form draft import', err);
+      setError('Could not import the supplied text. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleRefresh = useCallback(async () => {
+    if (!primaryOrgId || !view) return;
+    setRefreshing(true);
+    setError(null);
+    try {
+      const refreshed = await getDraftImport(primaryOrgId, view.id);
+      setView(refreshed);
+    } catch (err) {
+      logger.error('Failed to refresh form draft import', err);
+      setError('Could not refresh this draft. Please try again.');
+    } finally {
+      setRefreshing(false);
+    }
+  }, [primaryOrgId, view]);
+
+  const handleDiscard = async () => {
+    if (!primaryOrgId || !view) return;
+    setDiscarding(true);
+    setError(null);
+    try {
+      await discardDraftImport(primaryOrgId, view.id);
+      setView(null);
+    } catch (err) {
+      logger.error('Failed to discard form draft import', err);
+      setError(
+        'Could not discard this draft. It may already have been published - open it from Forms instead.'
+      );
+    } finally {
+      setDiscarding(false);
+    }
+  };
+
+  return (
+    <DevRouteGuard>
+      <PermissionGate
+        anyOf={[PERMISSIONS.FORMS_VIEW_ANY]}
+        deniedResource="Intake form import"
+        orgId={primaryOrgId}
+      >
+        <div className="OperationsWrapper">
+          <div className="TitleContainer">
+            <h1 className="text-heading-1 text-text-primary">Intake form draft import</h1>
+          </div>
+
+          <p className="text-body-3 text-text-secondary DraftImport-intro">
+            Paste supplied intake-form text to preview the fields it would create and how they
+            differ from an existing form&apos;s published version. Nothing is published from here -
+            review the draft, then use the existing form editor to publish or discard it.
+          </p>
+
+          {error && (
+            <p className="text-body-3 DraftImport-error" role="alert">
+              {error}
+            </p>
+          )}
+
+          {!view && (
+            <DraftImportForm
+              sourceOptions={sourceOptions}
+              submitting={submitting}
+              onSubmit={handleSubmit}
+            />
+          )}
+
+          {view && (
+            <DraftImportReview
+              view={view}
+              refreshing={refreshing}
+              discarding={discarding}
+              onRefresh={handleRefresh}
+              onDiscard={handleDiscard}
+            />
+          )}
+        </div>
+      </PermissionGate>
+    </DevRouteGuard>
+  );
+};
+
+export default DeveloperFormDraftImport;

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportForm.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportForm.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import DraftImportForm from './DraftImportForm';
+import './DeveloperFormDraftImport.css';
+
+const SOURCE_OPTIONS = [
+  { value: 'form-consent', label: 'Consent form' },
+  { value: 'form-intake', label: 'New client intake' },
+];
+
+const meta = {
+  title: 'Developers/DraftImportForm',
+  component: DraftImportForm,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Supplied-text entry for #3055/#3060: an optional existing form to diff against, and ' +
+          'the `label | type | required|optional | options` text the deterministic parser reads. ' +
+          'Owns only its own field state - the page decides what a submission does.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    sourceOptions: SOURCE_OPTIONS,
+    submitting: false,
+    onSubmit: fn(),
+  },
+} satisfies Meta<typeof DraftImportForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Empty, submit disabled',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Preview import' })).toBeDisabled();
+  },
+};
+
+export const FilledIn: Story = {
+  name: 'Text entered, source form chosen',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('button', { name: 'Existing form' }));
+    const panel = document.querySelector('[data-portal-dropdown]');
+    const option = within(panel as HTMLElement).getByText('Consent form');
+    await userEvent.click(option);
+
+    await userEvent.type(
+      canvas.getByLabelText(/Supplied form text/),
+      'Patient name | input | required'
+    );
+
+    const submit = canvas.getByRole('button', { name: 'Preview import' });
+    await expect(submit).toBeEnabled();
+    await userEvent.click(submit);
+
+    await expect(args.onSubmit).toHaveBeenCalledWith({
+      suppliedText: 'Patient name | input | required',
+      sourceFormId: 'form-consent',
+    });
+  },
+};
+
+export const Submitting: Story = {
+  name: 'Import in flight',
+  args: { submitting: true },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('button', { name: 'Importing…' })).toBeDisabled();
+  },
+};
+
+export const NoSourceForms: Story = {
+  name: 'No published forms to compare against',
+  args: { sourceOptions: [] },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Existing form' }));
+    const panel = document.querySelector('[data-portal-dropdown]');
+    await expect(
+      within(panel as HTMLElement).getByText('No published forms to compare against')
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportForm.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportForm.tsx
@@ -1,0 +1,87 @@
+'use client';
+import React, { useState } from 'react';
+
+import { Primary } from '@/app/ui/primitives/Buttons';
+import { Textarea } from '@/app/ui/Input';
+import LabelDropdown from '@/app/ui/inputs/Dropdown/LabelDropdown';
+import type { DropdownOption } from '@/app/hooks/useDropdown';
+
+export interface DraftImportFormInput {
+  suppliedText: string;
+  sourceFormId?: string;
+}
+
+const GRAMMAR_HELP =
+  'One field per line: label | type | required|optional | option1, option2. ' +
+  'Type must be one of input, textarea, richtext, number, dropdown, radio, checkbox, ' +
+  'boolean, date, signature. The required/optional segment and options are optional; ' +
+  'dropdown/radio/checkbox need a comma-separated options segment.';
+
+/**
+ * Owns its own field state, matching CreateKeyForm: the page decides what
+ * happens with a submission, this component only decides when one is valid.
+ */
+const DraftImportForm = ({
+  sourceOptions,
+  submitting,
+  onSubmit,
+}: {
+  sourceOptions: DropdownOption[];
+  submitting: boolean;
+  onSubmit: (input: DraftImportFormInput) => void;
+}) => {
+  const [suppliedText, setSuppliedText] = useState('');
+  const [sourceFormId, setSourceFormId] = useState<string | undefined>(undefined);
+
+  const handleSubmit = (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!suppliedText.trim() || submitting) return;
+    onSubmit({ suppliedText, sourceFormId });
+  };
+
+  return (
+    <form className="DraftImport-form yc-card-surface" onSubmit={handleSubmit}>
+      <label className="text-body-3 text-text-primary" htmlFor="draftImportSourceForm">
+        Existing form (optional)
+      </label>
+      <LabelDropdown
+        placeholder="Existing form"
+        options={sourceOptions}
+        onSelect={(option) => setSourceFormId(option.value || undefined)}
+        noOptionsMessage="No published forms to compare against"
+        searchable
+      />
+
+      <label className="text-body-3 text-text-primary" htmlFor="draftImportSuppliedText">
+        Supplied form text
+      </label>
+      <Textarea
+        id="draftImportSuppliedText"
+        className="DraftImport-textarea"
+        value={suppliedText}
+        onChange={(event) => setSuppliedText(event.target.value)}
+        placeholder={
+          'Patient name | input | required\nConsent to treatment | boolean | required\n' +
+          'Preferred contact method | dropdown | optional | Email, Phone, Text'
+        }
+        rows={10}
+        maxLength={20_000}
+        aria-describedby="draftImportGrammarHelp"
+      />
+      <p id="draftImportGrammarHelp" className="text-caption-2 text-text-tertiary">
+        {GRAMMAR_HELP}
+      </p>
+
+      <div className="DraftImport-formActions">
+        <Primary
+          text={submitting ? 'Importing…' : 'Preview import'}
+          type="submit"
+          isDisabled={!suppliedText.trim() || submitting}
+          style={{ maxWidth: 200 }}
+        />
+      </div>
+    </form>
+  );
+};
+
+export default DraftImportForm;

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportReview.stories.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportReview.stories.tsx
@@ -1,0 +1,130 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import DraftImportReview from './DraftImportReview';
+import type { DraftImportView } from '@/app/services/formDraftImportService';
+import './DeveloperFormDraftImport.css';
+
+const BASE_VIEW: DraftImportView = {
+  id: 'd1',
+  organisationId: 'org1',
+  sourceFormId: 'form-consent',
+  draftFormId: 'draft-form-1',
+  suppliedText:
+    'Patient name | input | required\nConsent to treatment | boolean | required\n' +
+    'Signature | inkblot',
+  fields: [
+    {
+      id: 'patient-name',
+      type: 'input',
+      label: 'Patient name',
+      required: true,
+      sourceLine: 1,
+    },
+    {
+      id: 'consent-to-treatment',
+      type: 'boolean',
+      label: 'Consent to treatment',
+      required: true,
+      sourceLine: 2,
+    },
+  ],
+  unsupportedConstructs: [
+    { line: 3, raw: 'Signature | inkblot', reason: 'Unknown field type "inkblot"' },
+  ],
+  diff: [
+    {
+      id: 'patient-name',
+      change: 'added',
+      after: { type: 'input', label: 'Patient name', required: true },
+    },
+    {
+      id: 'consent-to-treatment',
+      change: 'changed',
+      before: { type: 'boolean', label: 'Consent to treatment', required: false },
+      after: { type: 'boolean', label: 'Consent to treatment', required: true },
+    },
+    {
+      id: 'legacy-notes',
+      change: 'removed',
+      before: { type: 'textarea', label: 'Legacy notes', required: false },
+    },
+  ],
+  stale: false,
+  createdAt: '2026-09-12T00:00:00.000Z',
+  updatedAt: '2026-09-12T00:00:00.000Z',
+};
+
+const meta = {
+  title: 'Developers/DraftImportReview',
+  component: DraftImportReview,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'Renders one completed draft import: proposed fields, every unsupported construct ' +
+          '(shown with its source line and reason, never silently dropped), and the diff against ' +
+          "the source form's latest published version. Owns no server state.",
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    view: BASE_VIEW,
+    refreshing: false,
+    discarding: false,
+    onRefresh: fn(),
+    onDiscard: fn(),
+  },
+} satisfies Meta<typeof DraftImportReview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  name: 'Fields, unsupported construct, and a mixed diff',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Proposed fields (2)')).toBeInTheDocument();
+    await expect(canvas.getByText('Unsupported constructs (1)')).toBeInTheDocument();
+    await expect(canvas.getByText('Signature | inkblot')).toBeInTheDocument();
+    await expect(canvas.getByTestId('diff-patient-name')).toHaveTextContent('Added');
+    await expect(canvas.getByTestId('diff-consent-to-treatment')).toHaveTextContent('Changed');
+    await expect(canvas.getByTestId('diff-legacy-notes')).toHaveTextContent('Removed');
+    await expect(canvas.queryByRole('status')).not.toBeInTheDocument();
+  },
+};
+
+export const Stale: Story = {
+  name: 'Source form changed since import',
+  args: { view: { ...BASE_VIEW, stale: true } },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('status')).toHaveTextContent(/source form changed/);
+    await userEvent.click(canvas.getByRole('button', { name: 'Refresh' }));
+    await expect(args.onRefresh).toHaveBeenCalled();
+  },
+};
+
+export const NoSourceForm: Story = {
+  name: 'No source form selected - nothing to diff',
+  args: {
+    view: { ...BASE_VIEW, sourceFormId: null, diff: [] },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(
+      canvas.getByText('No source form was selected, so there is nothing to diff against.')
+    ).toBeInTheDocument();
+  },
+};
+
+export const DiscardDraft: Story = {
+  name: 'Discard sends the current draft id',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByRole('button', { name: 'Discard draft' }));
+    await expect(args.onDiscard).toHaveBeenCalled();
+  },
+};

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportReview.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportReview.tsx
@@ -38,7 +38,7 @@ const DraftImportReview = ({
   return (
     <div className="DraftImport-review">
       {view.stale && (
-        <div className="DraftImport-stale" role="status">
+        <output className="DraftImport-stale">
           <p>
             The source form changed since this draft was created. Refresh to see the current diff
             before deciding.
@@ -49,7 +49,7 @@ const DraftImportReview = ({
             isDisabled={refreshing}
             style={{ maxWidth: 140 }}
           />
-        </div>
+        </output>
       )}
 
       {view.unsupportedConstructs.length > 0 && (

--- a/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportReview.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperFormDraftImport/DraftImportReview.tsx
@@ -1,0 +1,135 @@
+'use client';
+import React from 'react';
+
+import { Secondary } from '@/app/ui/primitives/Buttons';
+import type { DraftImportView } from '@/app/services/formDraftImportService';
+
+const CHANGE_LABEL: Record<DraftImportView['diff'][number]['change'], string> = {
+  added: 'Added',
+  removed: 'Removed',
+  changed: 'Changed',
+  unchanged: 'Unchanged',
+};
+
+/**
+ * Renders one completed create/get response: the proposed fields, every
+ * unsupported construct (never silently dropped - #3060's own acceptance
+ * criterion), the diff against the source form's latest published version,
+ * and a staleness banner when the source changed since this draft was made.
+ *
+ * Owns no server state - the page passes the current view down and this
+ * component only decides how to lay it out.
+ */
+const DraftImportReview = ({
+  view,
+  refreshing,
+  discarding,
+  onRefresh,
+  onDiscard,
+}: {
+  view: DraftImportView;
+  refreshing: boolean;
+  discarding: boolean;
+  onRefresh: () => void;
+  onDiscard: () => void;
+}) => {
+  const changed = view.diff.filter((entry) => entry.change !== 'unchanged');
+
+  return (
+    <div className="DraftImport-review">
+      {view.stale && (
+        <div className="DraftImport-stale" role="status">
+          <p>
+            The source form changed since this draft was created. Refresh to see the current diff
+            before deciding.
+          </p>
+          <Secondary
+            text={refreshing ? 'Refreshing…' : 'Refresh'}
+            onClick={onRefresh}
+            isDisabled={refreshing}
+            style={{ maxWidth: 140 }}
+          />
+        </div>
+      )}
+
+      {view.unsupportedConstructs.length > 0 && (
+        <section className="DraftImport-section yc-card-surface">
+          <h2 className="text-heading-3 text-text-primary">
+            Unsupported constructs ({view.unsupportedConstructs.length})
+          </h2>
+          <ul className="DraftImport-unsupportedList">
+            {view.unsupportedConstructs.map((item) => (
+              <li key={`${item.line}-${item.raw}`}>
+                <span className="DraftImport-unsupportedLine">Line {item.line}:</span>{' '}
+                <code>{item.raw}</code>
+                <p className="text-caption-2 text-text-tertiary">{item.reason}</p>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      <section className="DraftImport-section yc-card-surface">
+        <h2 className="text-heading-3 text-text-primary">Proposed fields ({view.fields.length})</h2>
+        {view.fields.length === 0 ? (
+          <p className="text-body-3 text-text-secondary">No supported fields were parsed.</p>
+        ) : (
+          <ul className="DraftImport-fieldList">
+            {view.fields.map((field) => (
+              <li key={field.id}>
+                <span className="DraftImport-fieldLabel">{field.label}</span>
+                <span className="DraftImport-badge DraftImport-badge--type">{field.type}</span>
+                {field.required && (
+                  <span className="DraftImport-badge DraftImport-badge--required">Required</span>
+                )}
+                {field.options && field.options.length > 0 && (
+                  <span className="text-caption-2 text-text-tertiary">
+                    {field.options.map((option) => option.label).join(', ')}
+                  </span>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="DraftImport-section yc-card-surface">
+        <h2 className="text-heading-3 text-text-primary">
+          Diff against published version ({changed.length} changed)
+        </h2>
+        {view.diff.length === 0 ? (
+          <p className="text-body-3 text-text-secondary">
+            No source form was selected, so there is nothing to diff against.
+          </p>
+        ) : (
+          <ul className="DraftImport-diffList">
+            {view.diff.map((entry) => (
+              <li key={entry.id}>
+                <span
+                  className={`DraftImport-badge DraftImport-badge--${entry.change}`}
+                  data-testid={`diff-${entry.id}`}
+                >
+                  {CHANGE_LABEL[entry.change]}
+                </span>
+                <span className="DraftImport-fieldLabel">
+                  {entry.after?.label ?? entry.before?.label ?? entry.id}
+                </span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <div className="DraftImport-reviewActions">
+        <Secondary
+          text={discarding ? 'Discarding…' : 'Discard draft'}
+          onClick={onDiscard}
+          isDisabled={discarding}
+          style={{ maxWidth: 160 }}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default DraftImportReview;

--- a/apps/frontend/src/app/services/formDraftImportService.ts
+++ b/apps/frontend/src/app/services/formDraftImportService.ts
@@ -1,0 +1,76 @@
+import { getData, postData, deleteData } from '@/app/services/axios';
+import type { FieldOption, FieldType } from '@yosemite-crew/types';
+
+export interface DraftImportField {
+  id: string;
+  type: FieldType;
+  label: string;
+  required: boolean;
+  options?: FieldOption[];
+  sourceLine: number;
+}
+
+export interface DraftImportUnsupportedConstruct {
+  line: number;
+  raw: string;
+  reason: string;
+}
+
+export type DraftImportFieldChange = 'added' | 'removed' | 'changed' | 'unchanged';
+
+export interface DraftImportFieldSnapshot {
+  type: string;
+  label: string;
+  required: boolean;
+}
+
+export interface DraftImportFieldDiffEntry {
+  id: string;
+  change: DraftImportFieldChange;
+  before?: DraftImportFieldSnapshot;
+  after?: DraftImportFieldSnapshot;
+}
+
+export interface DraftImportView {
+  id: string;
+  organisationId: string;
+  sourceFormId: string | null;
+  draftFormId: string;
+  suppliedText: string;
+  fields: DraftImportField[];
+  unsupportedConstructs: DraftImportUnsupportedConstruct[];
+  diff: DraftImportFieldDiffEntry[];
+  stale: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface CreateDraftImportPayload {
+  suppliedText: string;
+  sourceFormId?: string;
+}
+
+const BASE = '/v1/form-draft-imports';
+
+export const createDraftImport = async (
+  organisationId: string,
+  payload: CreateDraftImportPayload
+): Promise<DraftImportView> => {
+  const res = await postData<{ data: DraftImportView }, CreateDraftImportPayload>(
+    `${BASE}/${organisationId}`,
+    payload
+  );
+  return res.data.data;
+};
+
+export const getDraftImport = async (
+  organisationId: string,
+  id: string
+): Promise<DraftImportView> => {
+  const res = await getData<{ data: DraftImportView }>(`${BASE}/${organisationId}/${id}`);
+  return res.data.data;
+};
+
+export const discardDraftImport = async (organisationId: string, id: string): Promise<void> => {
+  await deleteData(`${BASE}/${organisationId}/${id}`);
+};

--- a/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
+++ b/apps/frontend/src/app/ui/layout/Sidebar/Sidebar.tsx
@@ -56,6 +56,7 @@ const ROUTE_ICONS: Record<string, IconType> = {
   Network: IoGlobeOutline,
   Templates: IoBookOutline,
   'API Keys': IoKeyOutline,
+  'Form Draft Import': IoBookOutline,
   Billing: IoWalletOutline,
   'Website - Builder': IoGlobeOutline,
   Plugins: IoExtensionPuzzleOutline,
@@ -71,7 +72,10 @@ const APP_ROUTE_GROUPS = [
 ] as const;
 
 const DEV_ROUTE_GROUPS = [
-  { label: 'Developer', routeNames: ['Dashboard', 'API Keys', 'Billing', 'Website - Builder'] },
+  {
+    label: 'Developer',
+    routeNames: ['Dashboard', 'API Keys', 'Form Draft Import', 'Billing', 'Website - Builder'],
+  },
   { label: 'Platform', routeNames: ['Plugins', 'Documentation'] },
 ] as const;
 

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -29,6 +29,7 @@ const STRICT_CSP_PATH_PREFIXES = [
   '/developers/api-keys',
   '/developers/billing',
   '/developers/documentation',
+  '/developers/form-draft-import',
   '/developers/home',
   '/developers/plugins',
   '/developers/settings',


### PR DESCRIPTION
## Summary
- Developer-portal review UI for #3055's deterministic supplied-text-to-draft-form import: paste text in the documented grammar, preview proposed fields, unsupported constructs (never silently dropped), and the diff against a selected published form.
- Staleness re-fetch (`GET`) when the source form changed since the draft was created, and a discard action (`DELETE`) that surfaces the 409 "already published" case from the backend.
- No new backend endpoint - consumes #3055's contract as-is. No change to the existing form publish path.
- New route `/developers/form-draft-import`, added to the dev sidebar and the strict-CSP path list.

Base is `feat/3055-intake-form-draft-import` (not `dev`) because this UI depends on that PR's (#3061) API - this diff only shows the UI once #3061 merges and the base retargets.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `eslint` clean on all changed files
- [x] Full frontend jest suite: 1063 suites / 13538 tests green (includes the new page + service unit tests, and the repo's discovery-based guards: `cardSurface.test.ts` and `middleware.test.ts`, both updated for the new files)
- [x] `story-coverage.mjs`: all 3 new components have stories
- [x] Real Storybook build + `test-storybook` against it: 11/11 play-function tests pass across the 3 new story files