### PR TITLE
fix(frontend): update SignUp Storybook Dropdown queries

### DIFF
--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
@@ -97,8 +97,9 @@ export const Default: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    const role = canvas.getByRole('combobox', { name: 'I am' });
-    await expect(role).toHaveValue(CLINIC_ROLE);
+    const role = canvas.getByRole('button', { name: `I am: ${CLINIC_ROLE}` });
+    await expect(role).toHaveTextContent(CLINIC_ROLE);
+    await expect(role).toHaveAttribute('aria-haspopup', 'listbox');
 
     // The brand panel is the only h2 on the page; the two h1s are the page heading
     // and the preview decorator's sr-only landmark title, so read this by level.
@@ -201,7 +202,12 @@ export const DeveloperPane: Story = {
       'See the whole animal.'
     );
 
-    await userEvent.selectOptions(canvas.getByRole('combobox', { name: 'I am' }), DEVELOPER_ROLE);
+    const role = canvas.getByRole('button', { name: `I am: ${CLINIC_ROLE}` });
+    await userEvent.click(role);
+    const roleListbox = within(canvasElement.ownerDocument.body).getByRole('listbox', {
+      name: 'I am',
+    });
+    await userEvent.click(within(roleListbox).getByRole('option', { name: DEVELOPER_ROLE }));
 
     // Re-queried inside the waitFor rather than held from before the swap: the
     // headline is rebuilt around a different <em>, and the assertion should fail

--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUpPage.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUpPage.stories.tsx
@@ -32,6 +32,8 @@ const clearSignUpDraft = () => {
   removeStorageItem('session', 'yc_signup_draft');
 };
 
+const CLINIC_ROLE = 'A veterinary clinic, practice, or hospital';
+
 const DEVELOPER: AuthUser = {
   userId: 'user-dev-1',
   email: 'mira.lindqvist@yosemitecrew.example',
@@ -132,7 +134,7 @@ export const SignedOut: Story = {
   beforeEach: withSession({ status: 'unauthenticated', checkSession: fn(async () => null) }),
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('combobox', { name: 'I am' })).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: `I am: ${CLINIC_ROLE}` })).toBeInTheDocument();
     await expect(canvas.getByRole('button', { name: 'Create account' })).toBeInTheDocument();
     await expect(canvas.getByRole('heading', { level: 2 }).textContent).toBe(
       'See the whole animal.'


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The SignUp Storybook play functions still query the role selector as a native combobox. The production component now exposes a themed button/listbox control, so the stories fail before exercising the page.

## What is the new behavior?

The SignUp stories query the selector by its current accessible button name and interact with the portalled listbox when selecting the developer role.

Validation:

- Full frontend test suite: 1,063 suites and 13,548 tests passed.
- Frontend and monorepo lint/type-check gates passed.
- Default, DeveloperPane, and SignedOut stories completed in the running Storybook without Testing Library errors.
- Mutation check restored the stale combobox query and reproduced the original failure.
- Aikido scanned both changed files with no findings.

## Related Issue(s)

Fixes #3062
