### PR TITLE
feat(frontend): migration-audit review UI (#3057)

### DIFF
--- a/apps/frontend/src/app/(routes)/(app)/migration-audit/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/migration-audit/page.tsx
@@ -1,10 +1,5 @@
 import type { Metadata } from 'next';
 export const metadata: Metadata = { title: 'Migration audit — Yosemite Crew' };
-import React from 'react';
 import MigrationAudit from '@/app/features/onboarding/pages/MigrationAudit/MigrationAudit';
 
-function page() {
-  return <MigrationAudit />;
-}
-
-export default page;
+export default MigrationAudit;

--- a/apps/frontend/src/app/(routes)/(app)/migration-audit/page.tsx
+++ b/apps/frontend/src/app/(routes)/(app)/migration-audit/page.tsx
@@ -1,0 +1,10 @@
+import type { Metadata } from 'next';
+export const metadata: Metadata = { title: 'Migration audit — Yosemite Crew' };
+import React from 'react';
+import MigrationAudit from '@/app/features/onboarding/pages/MigrationAudit/MigrationAudit';
+
+function page() {
+  return <MigrationAudit />;
+}
+
+export default page;

--- a/apps/frontend/src/app/__tests__/features/onboarding/services/migrationAuditService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/onboarding/services/migrationAuditService.test.ts
@@ -1,10 +1,10 @@
-import axios from 'axios';
 import {
   createMigrationAuditRun,
   getMigrationAuditRun,
   getMigrationAuditUploadUrl,
   uploadMigrationAuditFile,
 } from '@/app/features/onboarding/services/migrationAuditService';
+import { uploadFileToS3 } from '@/app/features/inventory/services/inventoryUploadService';
 
 const postDataMock = jest.fn();
 const getDataMock = jest.fn();
@@ -17,9 +17,8 @@ jest.mock('@/app/services/axios', () => ({
   default: { get: jest.fn() },
 }));
 
-jest.mock('axios', () => ({
-  __esModule: true,
-  default: { put: jest.fn() },
+jest.mock('@/app/features/inventory/services/inventoryUploadService', () => ({
+  uploadFileToS3: jest.fn(),
 }));
 
 beforeEach(() => {
@@ -29,7 +28,7 @@ beforeEach(() => {
 describe('getMigrationAuditUploadUrl', () => {
   it('requests a presigned upload url for the organisation', async () => {
     postDataMock.mockResolvedValue({
-      data: { url: 'https://s3.example/put', key: 'orgs/org1/f.csv' },
+      data: { url: 'https://bucket.s3.amazonaws.com/put', key: 'orgs/org1/f.csv' },
     });
 
     const result = await getMigrationAuditUploadUrl('org1');
@@ -37,21 +36,44 @@ describe('getMigrationAuditUploadUrl', () => {
     expect(postDataMock).toHaveBeenCalledWith(
       '/v1/migration-audit/pms/organisations/org1/migration-audit/upload-url'
     );
-    expect(result).toEqual({ url: 'https://s3.example/put', key: 'orgs/org1/f.csv' });
+    expect(result).toEqual({
+      url: 'https://bucket.s3.amazonaws.com/put',
+      key: 'orgs/org1/f.csv',
+    });
+  });
+
+  it('rejects an organisation ID that could alter the request path', async () => {
+    await expect(getMigrationAuditUploadUrl('../other-org')).rejects.toThrow(
+      'Invalid organisation ID'
+    );
+    expect(postDataMock).not.toHaveBeenCalled();
   });
 });
 
 describe('uploadMigrationAuditFile', () => {
   it('PUTs the file with the fixed text/csv content type the presigned URL was signed for, not the file mime type', async () => {
-    (axios.put as jest.Mock).mockResolvedValue({});
+    (uploadFileToS3 as jest.Mock).mockResolvedValue(undefined);
     const file = new File(['external_id\n1'], 'owners.csv', { type: 'application/vnd.ms-excel' });
 
-    await uploadMigrationAuditFile('https://s3.example/put', file);
+    await uploadMigrationAuditFile('https://bucket.s3.amazonaws.com/put', file);
 
-    expect(axios.put).toHaveBeenCalledWith('https://s3.example/put', file, {
-      headers: { 'Content-Type': 'text/csv' },
-      withCredentials: false,
-    });
+    expect(uploadFileToS3).toHaveBeenCalledWith(
+      'https://bucket.s3.amazonaws.com/put',
+      expect.objectContaining({ name: 'owners.csv', type: 'text/csv' })
+    );
+  });
+
+  it.each([
+    'http://bucket.s3.amazonaws.com/put',
+    'https://user:password@bucket.s3.amazonaws.com/put',
+    'https://attacker.example/put',
+  ])('rejects an unsafe presigned URL: %s', async (uploadUrl) => {
+    const file = new File(['external_id\n1'], 'owners.csv', { type: 'text/csv' });
+
+    await expect(uploadMigrationAuditFile(uploadUrl, file)).rejects.toThrow(
+      'Invalid migration audit upload URL'
+    );
+    expect(uploadFileToS3).not.toHaveBeenCalled();
   });
 });
 
@@ -88,5 +110,12 @@ describe('getMigrationAuditRun', () => {
       '/v1/migration-audit/pms/organisations/org1/migration-audit/run1'
     );
     expect(result).toEqual(run);
+  });
+
+  it('rejects a run ID that could alter the request path', async () => {
+    await expect(getMigrationAuditRun('org1', '../other-run')).rejects.toThrow(
+      'Invalid migration audit run ID'
+    );
+    expect(getDataMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/frontend/src/app/__tests__/features/onboarding/services/migrationAuditService.test.ts
+++ b/apps/frontend/src/app/__tests__/features/onboarding/services/migrationAuditService.test.ts
@@ -1,0 +1,92 @@
+import axios from 'axios';
+import {
+  createMigrationAuditRun,
+  getMigrationAuditRun,
+  getMigrationAuditUploadUrl,
+  uploadMigrationAuditFile,
+} from '@/app/features/onboarding/services/migrationAuditService';
+
+const postDataMock = jest.fn();
+const getDataMock = jest.fn();
+
+jest.mock('@/app/services/axios', () => ({
+  __esModule: true,
+  postData: (...args: any[]) => postDataMock(...args),
+  getData: (...args: any[]) => getDataMock(...args),
+  deleteData: jest.fn(),
+  default: { get: jest.fn() },
+}));
+
+jest.mock('axios', () => ({
+  __esModule: true,
+  default: { put: jest.fn() },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('getMigrationAuditUploadUrl', () => {
+  it('requests a presigned upload url for the organisation', async () => {
+    postDataMock.mockResolvedValue({
+      data: { url: 'https://s3.example/put', key: 'orgs/org1/f.csv' },
+    });
+
+    const result = await getMigrationAuditUploadUrl('org1');
+
+    expect(postDataMock).toHaveBeenCalledWith(
+      '/v1/migration-audit/pms/organisations/org1/migration-audit/upload-url'
+    );
+    expect(result).toEqual({ url: 'https://s3.example/put', key: 'orgs/org1/f.csv' });
+  });
+});
+
+describe('uploadMigrationAuditFile', () => {
+  it('PUTs the file with the fixed text/csv content type the presigned URL was signed for, not the file mime type', async () => {
+    (axios.put as jest.Mock).mockResolvedValue({});
+    const file = new File(['external_id\n1'], 'owners.csv', { type: 'application/vnd.ms-excel' });
+
+    await uploadMigrationAuditFile('https://s3.example/put', file);
+
+    expect(axios.put).toHaveBeenCalledWith('https://s3.example/put', file, {
+      headers: { 'Content-Type': 'text/csv' },
+      withCredentials: false,
+    });
+  });
+});
+
+describe('createMigrationAuditRun', () => {
+  it('posts the collected source keys for the organisation', async () => {
+    postDataMock.mockResolvedValue({ data: { id: 'run1', status: 'PENDING' } });
+
+    const result = await createMigrationAuditRun('org1', { owners: 'orgs/org1/o.csv' });
+
+    expect(postDataMock).toHaveBeenCalledWith(
+      '/v1/migration-audit/pms/organisations/org1/migration-audit',
+      { sourceKeys: { owners: 'orgs/org1/o.csv' } }
+    );
+    expect(result).toEqual({ id: 'run1', status: 'PENDING' });
+  });
+});
+
+describe('getMigrationAuditRun', () => {
+  it('fetches a run by id for the organisation', async () => {
+    const run = {
+      id: 'run1',
+      status: 'COMPLETED',
+      summary: null,
+      errorMessage: null,
+      createdAt: '2026-09-12T00:00:00.000Z',
+      completedAt: '2026-09-12T00:00:05.000Z',
+      outcome: { resourceType: 'OperationOutcome', issue: [] },
+    };
+    getDataMock.mockResolvedValue({ data: run });
+
+    const result = await getMigrationAuditRun('org1', 'run1');
+
+    expect(getDataMock).toHaveBeenCalledWith(
+      '/v1/migration-audit/pms/organisations/org1/migration-audit/run1'
+    );
+    expect(result).toEqual(run);
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/MigrationAudit.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/MigrationAudit.test.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock('@/app/features/onboarding/services/migrationAuditService', () => ({
+  getMigrationAuditUploadUrl: jest.fn(),
+  uploadMigrationAuditFile: jest.fn(),
+  createMigrationAuditRun: jest.fn(),
+  getMigrationAuditRun: jest.fn(),
+}));
+
+jest.mock('@/app/ui/layout/guards/ProtectedRoute', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/app/ui/layout/guards/PermissionGate', () => ({
+  __esModule: true,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  __esModule: true,
+  Primary: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+  Secondary: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+jest.mock('@/app/lib/logger', () => ({
+  logger: { error: jest.fn(), info: jest.fn(), warn: jest.fn(), debug: jest.fn() },
+}));
+
+import MigrationAudit, {
+  POLL_INTERVAL_MS,
+} from '@/app/features/onboarding/pages/MigrationAudit/MigrationAudit';
+import {
+  createMigrationAuditRun,
+  getMigrationAuditRun,
+  getMigrationAuditUploadUrl,
+  uploadMigrationAuditFile,
+} from '@/app/features/onboarding/services/migrationAuditService';
+import { useOrgStore } from '@/app/stores/orgStore';
+import { logger } from '@/app/lib/logger';
+
+const loggerErrorMock = logger.error as jest.Mock;
+
+const getUploadUrlMock = getMigrationAuditUploadUrl as jest.Mock;
+const uploadFileMock = uploadMigrationAuditFile as jest.Mock;
+const createRunMock = createMigrationAuditRun as jest.Mock;
+const getRunMock = getMigrationAuditRun as jest.Mock;
+
+const csvFile = (name: string) => new File(['external_id\n1'], name, { type: 'text/csv' });
+
+const selectRequiredFiles = async (user: ReturnType<typeof userEvent.setup>) => {
+  await user.upload(screen.getByLabelText('Owners'), csvFile('owners.csv'));
+  await user.upload(screen.getByLabelText('Animals'), csvFile('animals.csv'));
+  await user.upload(screen.getByLabelText('Appointments'), csvFile('appointments.csv'));
+};
+
+const COMPLETED_RUN = {
+  id: 'run1',
+  status: 'COMPLETED' as const,
+  summary: {
+    OWNERS: {
+      status: 'ASSESSED' as const,
+      totalRows: 2,
+      duplicateIdentifiers: 0,
+      orphanReferences: 0,
+    },
+    ANIMALS: {
+      status: 'ASSESSED' as const,
+      totalRows: 1,
+      duplicateIdentifiers: 0,
+      orphanReferences: 1,
+    },
+  },
+  errorMessage: null,
+  createdAt: '2026-09-12T00:00:00.000Z',
+  completedAt: '2026-09-12T00:00:05.000Z',
+  outcome: {
+    resourceType: 'OperationOutcome' as const,
+    issue: [
+      {
+        severity: 'error',
+        code: 'orphan_reference',
+        diagnostics: 'animals.csv row 1 references owner_external_id not present in owners.csv.',
+        expression: ['animals.csv[row 1]'],
+      },
+    ],
+  },
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  useOrgStore.setState({ primaryOrgId: 'org1' });
+  getUploadUrlMock.mockResolvedValue({ url: 'https://s3.example/put', key: 'orgs/org1/x.csv' });
+  uploadFileMock.mockResolvedValue(undefined);
+});
+
+describe('MigrationAudit page', () => {
+  it('disables submit until every required file is chosen', async () => {
+    const user = userEvent.setup();
+    render(<MigrationAudit />);
+
+    expect(screen.getByRole('button', { name: 'Run migration audit' })).toBeDisabled();
+
+    await selectRequiredFiles(user);
+    expect(screen.getByRole('button', { name: 'Run migration audit' })).toBeEnabled();
+  });
+
+  it('re-disables submit when a required file is cleared after being chosen', async () => {
+    const user = userEvent.setup();
+    render(<MigrationAudit />);
+
+    await selectRequiredFiles(user);
+    expect(screen.getByRole('button', { name: 'Run migration audit' })).toBeEnabled();
+
+    fireEvent.change(screen.getByLabelText('Owners'), { target: { files: [] } });
+    expect(screen.getByRole('button', { name: 'Run migration audit' })).toBeDisabled();
+  });
+
+  it(
+    'uploads each required file, creates the run, and polls to completion',
+    async () => {
+      const user = userEvent.setup();
+      createRunMock.mockResolvedValue({ id: 'run1', status: 'PENDING' });
+      getRunMock.mockResolvedValue(COMPLETED_RUN);
+
+      render(<MigrationAudit />);
+      await selectRequiredFiles(user);
+      await user.click(screen.getByRole('button', { name: 'Run migration audit' }));
+
+      expect(getUploadUrlMock).toHaveBeenCalledTimes(3);
+      expect(uploadFileMock).toHaveBeenCalledTimes(3);
+      expect(createRunMock).toHaveBeenCalledWith('org1', {
+        owners: 'orgs/org1/x.csv',
+        animals: 'orgs/org1/x.csv',
+        appointments: 'orgs/org1/x.csv',
+      });
+      expect(screen.getByText(/Reading the uploaded files/)).toBeInTheDocument();
+
+      // The container polls on a real POLL_INTERVAL_MS timer, so this waits
+      // for the real interval to fire rather than faking it - simpler and
+      // less brittle than reconciling fake timers with the awaited upload
+      // chain that precedes it.
+      await waitFor(() => expect(getRunMock).toHaveBeenCalledWith('org1', 'run1'), {
+        timeout: POLL_INTERVAL_MS + 2000,
+      });
+      expect(await screen.findByText('Findings (1)')).toBeInTheDocument();
+      expect(
+        screen.getByText(/references owner_external_id not present in owners.csv/)
+      ).toBeInTheDocument();
+    },
+    POLL_INTERVAL_MS + 5000
+  );
+
+  it(
+    'logs and retries a transient poll failure instead of surfacing it as an error',
+    async () => {
+      const user = userEvent.setup();
+      createRunMock.mockResolvedValue({ id: 'run1', status: 'PENDING' });
+      getRunMock.mockRejectedValueOnce(new Error('network blip')).mockResolvedValue(COMPLETED_RUN);
+
+      render(<MigrationAudit />);
+      await selectRequiredFiles(user);
+      await user.click(screen.getByRole('button', { name: 'Run migration audit' }));
+
+      await waitFor(
+        () =>
+          expect(loggerErrorMock).toHaveBeenCalledWith(
+            'Failed to poll migration audit run',
+            expect.any(Error)
+          ),
+        { timeout: POLL_INTERVAL_MS + 2000 }
+      );
+      expect(
+        screen.queryByText('Could not start the migration audit. Please try again.')
+      ).not.toBeInTheDocument();
+
+      expect(
+        await screen.findByText('Findings (1)', {}, { timeout: POLL_INTERVAL_MS + 2000 })
+      ).toBeInTheDocument();
+    },
+    2 * POLL_INTERVAL_MS + 5000
+  );
+
+  it(
+    'shows the failure reason and lets the operator start a new audit',
+    async () => {
+      const user = userEvent.setup();
+      createRunMock.mockResolvedValue({ id: 'run1', status: 'PENDING' });
+      getRunMock.mockResolvedValue({
+        id: 'run1',
+        status: 'FAILED',
+        summary: null,
+        errorMessage: 'owners.csv could not be parsed as CSV.',
+        createdAt: '2026-09-12T00:00:00.000Z',
+        completedAt: '2026-09-12T00:00:05.000Z',
+        outcome: { resourceType: 'OperationOutcome', issue: [] },
+      });
+
+      render(<MigrationAudit />);
+      await selectRequiredFiles(user);
+      await user.click(screen.getByRole('button', { name: 'Run migration audit' }));
+
+      expect(
+        await screen.findByText(
+          'owners.csv could not be parsed as CSV.',
+          {},
+          { timeout: POLL_INTERVAL_MS + 2000 }
+        )
+      ).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: 'Start a new audit' }));
+      expect(screen.getByRole('button', { name: 'Run migration audit' })).toBeInTheDocument();
+    },
+    POLL_INTERVAL_MS + 5000
+  );
+
+  it('shows an error banner when the upload fails', async () => {
+    const user = userEvent.setup();
+    getUploadUrlMock.mockRejectedValue(new Error('boom'));
+
+    render(<MigrationAudit />);
+    await selectRequiredFiles(user);
+    await user.click(screen.getByRole('button', { name: 'Run migration audit' }));
+
+    expect(
+      await screen.findByText('Could not start the migration audit. Please try again.')
+    ).toBeInTheDocument();
+    expect(createRunMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/MigrationAudit.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/MigrationAudit.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import '@testing-library/jest-dom';
 
@@ -223,6 +223,65 @@ describe('MigrationAudit page', () => {
       expect(screen.getByRole('button', { name: 'Run migration audit' })).toBeInTheDocument();
     },
     POLL_INTERVAL_MS + 5000
+  );
+
+  it(
+    "drops the previous organisation's completed report when the active organisation changes",
+    async () => {
+      const user = userEvent.setup();
+      createRunMock.mockResolvedValue({ id: 'run1', status: 'PENDING' });
+      getRunMock.mockResolvedValue(COMPLETED_RUN);
+
+      render(<MigrationAudit />);
+      await selectRequiredFiles(user);
+      await user.click(screen.getByRole('button', { name: 'Run migration audit' }));
+      expect(
+        await screen.findByText('Findings (1)', {}, { timeout: POLL_INTERVAL_MS + 2000 })
+      ).toBeInTheDocument();
+
+      await act(async () => {
+        useOrgStore.setState({ primaryOrgId: 'org2' });
+      });
+
+      expect(screen.queryByText('Findings (1)')).not.toBeInTheDocument();
+      // The chosen files went with it, so org2 starts from an empty form.
+      expect(screen.getByRole('button', { name: 'Run migration audit' })).toBeDisabled();
+
+      // And it is gone for good - switching back does not resurrect it.
+      await act(async () => {
+        useOrgStore.setState({ primaryOrgId: 'org1' });
+      });
+      expect(screen.queryByText('Findings (1)')).not.toBeInTheDocument();
+    },
+    2 * POLL_INTERVAL_MS + 5000
+  );
+
+  it(
+    "stops polling the previous organisation's run when the active organisation changes",
+    async () => {
+      const user = userEvent.setup();
+      createRunMock.mockResolvedValue({ id: 'run1', status: 'PENDING' });
+      getRunMock.mockResolvedValue({ ...COMPLETED_RUN, status: 'RUNNING', completedAt: null });
+
+      render(<MigrationAudit />);
+      await selectRequiredFiles(user);
+      await user.click(screen.getByRole('button', { name: 'Run migration audit' }));
+      await waitFor(() => expect(getRunMock).toHaveBeenCalledWith('org1', 'run1'), {
+        timeout: POLL_INTERVAL_MS + 2000,
+      });
+
+      await act(async () => {
+        useOrgStore.setState({ primaryOrgId: 'org2' });
+      });
+      getRunMock.mockClear();
+
+      expect(screen.queryByText(/Reading the uploaded files/)).not.toBeInTheDocument();
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 2 * POLL_INTERVAL_MS));
+      });
+      expect(getRunMock).not.toHaveBeenCalled();
+    },
+    4 * POLL_INTERVAL_MS + 5000
   );
 
   it('shows an error banner when the upload fails', async () => {

--- a/apps/frontend/src/app/__tests__/pages/MigrationAuditReview.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/MigrationAuditReview.test.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  __esModule: true,
+  Secondary: ({ text, onClick }: any) => (
+    <button type="button" onClick={onClick}>
+      {text}
+    </button>
+  ),
+}));
+
+import MigrationAuditReview from '@/app/features/onboarding/pages/MigrationAudit/MigrationAuditReview';
+import type { MigrationAuditRun } from '@/app/features/onboarding/services/migrationAuditService';
+
+const BASE_RUN: MigrationAuditRun = {
+  id: 'run1',
+  status: 'PENDING',
+  summary: null,
+  errorMessage: null,
+  createdAt: '2026-09-12T00:00:00.000Z',
+  completedAt: null,
+  outcome: { resourceType: 'OperationOutcome', issue: [] },
+};
+
+describe('MigrationAuditReview', () => {
+  it('announces progress while PENDING, with no restart action', () => {
+    render(<MigrationAuditReview run={BASE_RUN} onStartNew={jest.fn()} />);
+    expect(screen.getByRole('status')).toHaveTextContent(/Reading the uploaded files/);
+    expect(screen.queryByRole('button', { name: 'Start a new audit' })).not.toBeInTheDocument();
+  });
+
+  it('announces progress while RUNNING too', () => {
+    render(<MigrationAuditReview run={{ ...BASE_RUN, status: 'RUNNING' }} />);
+    expect(screen.getByRole('status')).toBeInTheDocument();
+  });
+
+  it('shows the failure reason and offers a restart, falling back to a generic message when none is given', async () => {
+    const user = userEvent.setup();
+    const onStartNew = jest.fn();
+    render(
+      <MigrationAuditReview
+        run={{ ...BASE_RUN, status: 'FAILED', errorMessage: null }}
+        onStartNew={onStartNew}
+      />
+    );
+    expect(screen.getByRole('alert')).toHaveTextContent(/could not be completed/);
+
+    await user.click(screen.getByRole('button', { name: 'Start a new audit' }));
+    expect(onStartNew).toHaveBeenCalled();
+  });
+
+  it('shows a not-assessed section with its reason, and an empty findings state', () => {
+    render(
+      <MigrationAuditReview
+        run={{
+          ...BASE_RUN,
+          status: 'COMPLETED',
+          summary: {
+            OWNERS: {
+              status: 'NOT_ASSESSED',
+              notAssessedReason: 'file_not_provided',
+              totalRows: 0,
+              duplicateIdentifiers: 0,
+              orphanReferences: 0,
+            },
+          },
+        }}
+      />
+    );
+    expect(screen.getByText('Not assessed (file_not_provided).')).toBeInTheDocument();
+    expect(screen.getByText('Findings (0)')).toBeInTheDocument();
+    expect(screen.getByText(/No findings/)).toBeInTheDocument();
+  });
+
+  it('groups findings by source file in section order and by severity within a group, including an unrecognised file and a fatal severity', () => {
+    render(
+      <MigrationAuditReview
+        run={{
+          ...BASE_RUN,
+          status: 'COMPLETED',
+          summary: {
+            OWNERS: {
+              status: 'ASSESSED',
+              totalRows: 3,
+              duplicateIdentifiers: 1,
+              orphanReferences: 0,
+            },
+          },
+          outcome: {
+            resourceType: 'OperationOutcome',
+            issue: [
+              {
+                severity: 'warning',
+                code: 'duplicate_identifier',
+                diagnostics: 'owners.csv row 2 repeats external_id already seen at row 1.',
+                expression: ['owners.csv[row 2]'],
+              },
+              {
+                severity: 'fatal',
+                code: 'missing_file',
+                diagnostics: 'appointments.csv was not provided.',
+                expression: ['appointments.csv'],
+              },
+              {
+                severity: 'information',
+                code: 'unsupported_column',
+                diagnostics: 'notes.csv has column(s) outside the supported set: extra.',
+                expression: ['notes.csv'],
+              },
+            ],
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText('Findings (3)')).toBeInTheDocument();
+    const groupTitles = screen
+      .getAllByText(/\.csv$/, { selector: 'h3' })
+      .map((el) => el.textContent);
+    // owners.csv (order 0) and appointments.csv (order 2) sort ahead of the
+    // unrecognised notes.csv, which falls back to the end of the order.
+    expect(groupTitles).toEqual(['owners.csv', 'appointments.csv', 'notes.csv']);
+
+    expect(screen.getByText('Row 2')).toBeInTheDocument();
+    expect(screen.getByText('fatal')).toBeInTheDocument();
+    expect(screen.getByText('information')).toBeInTheDocument();
+  });
+});

--- a/apps/frontend/src/app/__tests__/pages/MigrationAuditUploadForm.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/MigrationAuditUploadForm.test.tsx
@@ -1,0 +1,108 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import '@testing-library/jest-dom';
+
+jest.mock('@/app/ui/primitives/Buttons', () => ({
+  __esModule: true,
+  Primary: ({ text, onClick, isDisabled }: any) => (
+    <button type="button" onClick={onClick} disabled={isDisabled}>
+      {text}
+    </button>
+  ),
+}));
+
+import MigrationAuditUploadForm from '@/app/features/onboarding/pages/MigrationAudit/MigrationAuditUploadForm';
+
+const csvFile = (name: string) => new File(['external_id\n1'], name, { type: 'text/csv' });
+
+describe('MigrationAuditUploadForm', () => {
+  it('publishes the limits and every section with its required/optional badge and columns', () => {
+    render(
+      <MigrationAuditUploadForm
+        files={{}}
+        onFileChange={jest.fn()}
+        submitting={false}
+        canSubmit={false}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    expect(screen.getByText(/up to 5 MB and 5,000 rows/)).toBeInTheDocument();
+    expect(screen.getByLabelText('Owners')).toBeInTheDocument();
+    expect(
+      screen.getByText('Columns: external_id, first_name, last_name, email, phone')
+    ).toBeInTheDocument();
+    expect(screen.getAllByText('Required')).toHaveLength(3);
+    expect(screen.getByText('Optional')).toBeInTheDocument();
+  });
+
+  it('reports a chosen file and shows its name', async () => {
+    const user = userEvent.setup();
+    const onFileChange = jest.fn();
+    render(
+      <MigrationAuditUploadForm
+        files={{}}
+        onFileChange={onFileChange}
+        submitting={false}
+        canSubmit={false}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    await user.upload(screen.getByLabelText('Owners'), csvFile('owners.csv'));
+    expect(onFileChange).toHaveBeenCalledWith(
+      'owners',
+      expect.objectContaining({ name: 'owners.csv' })
+    );
+  });
+
+  it('reports null when a chosen file is cleared', () => {
+    const onFileChange = jest.fn();
+    render(
+      <MigrationAuditUploadForm
+        files={{ owners: csvFile('owners.csv') }}
+        onFileChange={onFileChange}
+        submitting={false}
+        canSubmit={false}
+        onSubmit={jest.fn()}
+      />
+    );
+
+    fireEvent.change(screen.getByLabelText('Owners'), { target: { files: [] } });
+    expect(onFileChange).toHaveBeenCalledWith('owners', null);
+  });
+
+  it('disables the file inputs and shows the uploading label while submitting', () => {
+    render(
+      <MigrationAuditUploadForm
+        files={{ owners: csvFile('owners.csv') }}
+        onFileChange={jest.fn()}
+        submitting
+        canSubmit
+        onSubmit={jest.fn()}
+      />
+    );
+
+    expect(screen.getByLabelText('Owners')).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Uploading…' })).toBeDisabled();
+    expect(screen.getByText('owners.csv')).toBeInTheDocument();
+  });
+
+  it('calls onSubmit when the run button is clicked while enabled', async () => {
+    const user = userEvent.setup();
+    const onSubmit = jest.fn();
+    render(
+      <MigrationAuditUploadForm
+        files={{}}
+        onFileChange={jest.fn()}
+        submitting={false}
+        canSubmit
+        onSubmit={onSubmit}
+      />
+    );
+
+    await user.click(screen.getByRole('button', { name: 'Run migration audit' }));
+    expect(onSubmit).toHaveBeenCalled();
+  });
+});

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.css
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.css
@@ -1,0 +1,160 @@
+/**
+ * Migration-audit review UI (#3057), the frontend follow-up to #3056's
+ * read-only API. Card frame (background/border/radius/shadow) comes from the
+ * shared `.yc-card-surface` class in globals.css - these rules only add
+ * layout, same split as DeveloperFormDraftImport.css.
+ */
+
+.MigrationAudit-intro {
+  margin: 8px 0 24px;
+  max-width: 640px;
+}
+
+.MigrationAudit-error {
+  margin-bottom: 16px;
+  color: var(--color-text-error);
+}
+
+/* Upload step ---------------------------------------------------------------- */
+
+.MigrationAudit-upload {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  max-width: 640px;
+  padding: 20px 22px;
+}
+
+.MigrationAudit-limits {
+  margin: 0;
+}
+
+.MigrationAudit-fileList {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.MigrationAudit-fileRow {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  background: var(--color-inset);
+  border: 1px solid var(--divider);
+  border-radius: 12px;
+}
+
+.MigrationAudit-fileHeading {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.MigrationAudit-columns {
+  margin: 0;
+}
+
+.MigrationAudit-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 9px;
+  border: 1px solid transparent;
+  border-radius: 9999px;
+  font-size: 0.625rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  white-space: nowrap;
+}
+
+.MigrationAudit-badge--required {
+  background: var(--status-completed-bg);
+  color: var(--status-completed-text);
+  border-color: var(--status-completed-border);
+}
+
+.MigrationAudit-badge--optional {
+  background: var(--color-inset);
+  color: var(--color-text-secondary);
+  border-color: var(--divider);
+}
+
+/* Review ---------------------------------------------------------------------- */
+
+.MigrationAudit-progress {
+  display: block;
+  padding: 18px 20px;
+}
+
+.MigrationAudit-failed {
+  padding: 18px 20px;
+}
+
+.MigrationAudit-review {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  max-width: 780px;
+}
+
+.MigrationAudit-summaryGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 14px;
+}
+
+.MigrationAudit-summaryCard {
+  padding: 16px 18px;
+}
+
+.MigrationAudit-summaryStats {
+  margin: 10px 0 0;
+  display: flex;
+  gap: 18px;
+}
+
+.MigrationAudit-summaryStats dt {
+  margin: 0;
+}
+
+.MigrationAudit-summaryStats dd {
+  margin: 2px 0 0;
+}
+
+.MigrationAudit-findings {
+  padding: 18px 20px;
+}
+
+.MigrationAudit-findingGroup + .MigrationAudit-findingGroup {
+  margin-top: 18px;
+}
+
+.MigrationAudit-findingGroupTitle {
+  margin: 0 0 8px;
+}
+
+.MigrationAudit-findingList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.MigrationAudit-findingList li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 12px;
+  background: var(--color-inset);
+  border: 1px solid var(--divider);
+  border-radius: 10px;
+}
+
+.MigrationAudit-findingRow {
+  font-weight: 700;
+  color: var(--color-text-secondary);
+}

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.stories.tsx
@@ -47,6 +47,9 @@ const stubDirectUpload = () => {
 };
 
 const ORG_ID = 'org-storybook';
+const OTHER_ORG_ID = 'org-storybook-2';
+const PRESIGNED_URL =
+  'https://yosemite-crew-migration.s3.eu-central-1.amazonaws.com/orgs/org-storybook/f.csv?X-Amz-Signature=storybook';
 
 const OWNER_MEMBERSHIP: UserOrganization = {
   practitionerReference: 'Practitioner/user-storybook',
@@ -75,7 +78,13 @@ const seedStores = () => {
   });
   useOrgStore.setState({
     primaryOrgId: ORG_ID,
-    membershipsByOrgId: { [ORG_ID]: OWNER_MEMBERSHIP },
+    membershipsByOrgId: {
+      [ORG_ID]: OWNER_MEMBERSHIP,
+      [OTHER_ORG_ID]: {
+        ...OWNER_MEMBERSHIP,
+        organizationReference: `Organization/${OTHER_ORG_ID}`,
+      },
+    },
     status: 'loaded',
   });
 
@@ -132,7 +141,10 @@ export const RunToCompletion: Story = {
     const method = config.method?.toLowerCase();
     const url = config.url ?? '';
     if (method === 'post' && url.endsWith('/upload-url')) {
-      return { status: 200, body: { url: 'https://s3.example/put', key: `orgs/${ORG_ID}/f.csv` } };
+      // uploadMigrationAuditFile rejects anything that is not an https
+      // *.amazonaws.com host, so the stub has to be shaped like a real
+      // presigned S3 URL or the upload never happens.
+      return { status: 200, body: { url: PRESIGNED_URL, key: `orgs/${ORG_ID}/f.csv` } };
     }
     if (method === 'post') {
       return { status: 201, body: { id: 'run-storybook', status: 'PENDING' } };
@@ -196,6 +208,20 @@ export const RunToCompletion: Story = {
       timeout: 10_000,
     });
     await expect(canvas.getByText('Row 2')).toBeInTheDocument();
+  },
+};
+
+export const OrganisationSwitch: Story = {
+  name: "Switching organisation clears the previous one's report",
+  beforeEach: RunToCompletion.beforeEach,
+  play: async (context) => {
+    await RunToCompletion.play?.(context);
+    const canvas = within(context.canvasElement);
+
+    useOrgStore.setState({ primaryOrgId: OTHER_ORG_ID });
+
+    await waitFor(() => expect(canvas.queryByText('Findings (1)')).not.toBeInTheDocument());
+    await expect(await canvas.findByLabelText('Owners')).toHaveValue('');
   },
 };
 

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.stories.tsx
@@ -1,0 +1,223 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import rawAxios, { type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+import { expect, userEvent, waitFor, within } from 'storybook/test';
+import type { UserOrganization } from '@yosemite-crew/types';
+
+import api, { clearInFlightGetRequests } from '@/app/services/axios';
+import { useAuthStore } from '@/app/stores/authStore';
+import { useOrgStore } from '@/app/stores/orgStore';
+import MigrationAudit from './MigrationAudit';
+
+/**
+ * Drives the real component against the real service layer, only the axios
+ * ADAPTER is swapped - same shape as DeveloperFormDraftImport.stories.tsx (#3060)
+ * and for the same reason: stubbing the service module would hide a change to
+ * the request shape or response envelope.
+ */
+type Handler = (config: InternalAxiosRequestConfig) => { status?: number; body?: unknown };
+
+const stubApi = (handler: Handler) => {
+  const previous = api.defaults.adapter;
+  api.defaults.adapter = async (config) => {
+    const { status = 200, body = [] } = handler(config);
+    if (status >= 400) {
+      throw Object.assign(new Error(`Request failed with status ${status}`), {
+        response: { status, data: body, config },
+        config,
+      });
+    }
+    return { data: body, status, statusText: 'OK', headers: {}, config } as AxiosResponse;
+  };
+  return () => {
+    api.defaults.adapter = previous;
+  };
+};
+
+// axios.put targets the presigned S3 URL directly (an absolute, non-API
+// origin, deliberately with `withCredentials: false`), which is a different
+// axios instance from the api client stubbed above - stub the plain axios
+// default adapter too so the direct upload never leaves this story either.
+const stubDirectUpload = () => {
+  const previous = rawAxios.defaults.adapter;
+  rawAxios.defaults.adapter = async (config: InternalAxiosRequestConfig) =>
+    ({ data: {}, status: 200, statusText: 'OK', headers: {}, config }) as AxiosResponse;
+  return () => {
+    rawAxios.defaults.adapter = previous;
+  };
+};
+
+const ORG_ID = 'org-storybook';
+
+const OWNER_MEMBERSHIP: UserOrganization = {
+  practitionerReference: 'Practitioner/user-storybook',
+  organizationReference: `Organization/${ORG_ID}`,
+  roleCode: 'OWNER',
+  roleDisplay: 'Owner',
+  active: true,
+};
+
+const seedStores = () => {
+  const authSnapshot = useAuthStore.getState();
+  const orgSnapshot = useOrgStore.getState();
+
+  useAuthStore.setState({
+    status: 'authenticated',
+    role: 'owner',
+    user: {
+      userId: 'owner-storybook',
+      email: 'owner@example.test',
+      authProfile: null,
+      loginMethod: 'emailpassword',
+      emailVerified: true,
+      getUsername: () => 'owner-storybook',
+    },
+    attributes: { sub: 'owner-storybook', email: 'owner@example.test', email_verified: 'true' },
+  });
+  useOrgStore.setState({
+    primaryOrgId: ORG_ID,
+    membershipsByOrgId: { [ORG_ID]: OWNER_MEMBERSHIP },
+    status: 'loaded',
+  });
+
+  return () => {
+    useAuthStore.setState(authSnapshot);
+    useOrgStore.setState(orgSnapshot);
+  };
+};
+
+const setup = (handler: Handler) => () => {
+  clearInFlightGetRequests();
+  const restoreStores = seedStores();
+  const restoreApi = stubApi(handler);
+  const restoreUpload = stubDirectUpload();
+  return () => {
+    restoreUpload();
+    restoreApi();
+    restoreStores();
+    clearInFlightGetRequests();
+  };
+};
+
+const csvFile = (name: string) => new File(['external_id\n1'], name, { type: 'text/csv' });
+
+const meta = {
+  title: 'Onboarding/MigrationAudit',
+  component: MigrationAudit,
+  parameters: {
+    layout: 'fullscreen',
+    nextjs: {
+      appDirectory: true,
+      navigation: { pathname: '/migration-audit' },
+    },
+    docs: {
+      description: {
+        component:
+          "Review surface for #3056's read-only migration-audit API: upload the owners/animals/" +
+          'appointments CSVs (attachments optional), create a run, poll until it completes, then ' +
+          'review the summary and every finding before deciding whether to proceed with an import.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  globals: { viewport: { value: 'desktop', isRotated: false } },
+  beforeEach: setup(() => ({ body: [] })),
+} satisfies Meta<typeof MigrationAudit>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const RunToCompletion: Story = {
+  name: 'Upload, create the run, and review the completed findings',
+  beforeEach: setup((config) => {
+    const method = config.method?.toLowerCase();
+    const url = config.url ?? '';
+    if (method === 'post' && url.endsWith('/upload-url')) {
+      return { status: 200, body: { url: 'https://s3.example/put', key: `orgs/${ORG_ID}/f.csv` } };
+    }
+    if (method === 'post') {
+      return { status: 201, body: { id: 'run-storybook', status: 'PENDING' } };
+    }
+    if (method === 'get') {
+      return {
+        status: 200,
+        body: {
+          id: 'run-storybook',
+          status: 'COMPLETED',
+          summary: {
+            OWNERS: {
+              status: 'ASSESSED',
+              totalRows: 2,
+              duplicateIdentifiers: 0,
+              orphanReferences: 0,
+            },
+            ANIMALS: {
+              status: 'ASSESSED',
+              totalRows: 2,
+              duplicateIdentifiers: 0,
+              orphanReferences: 1,
+            },
+            APPOINTMENTS: {
+              status: 'ASSESSED',
+              totalRows: 2,
+              duplicateIdentifiers: 0,
+              orphanReferences: 0,
+            },
+          },
+          errorMessage: null,
+          createdAt: '2026-09-12T00:00:00.000Z',
+          completedAt: '2026-09-12T00:00:05.000Z',
+          outcome: {
+            resourceType: 'OperationOutcome',
+            issue: [
+              {
+                severity: 'error',
+                code: 'orphan_reference',
+                diagnostics:
+                  'animals.csv row 2 references owner_external_id not present in owners.csv.',
+                expression: ['animals.csv[row 2]'],
+              },
+            ],
+          },
+        },
+      };
+    }
+    return { body: [] };
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.upload(await canvas.findByLabelText('Owners'), csvFile('owners.csv'));
+    await userEvent.upload(canvas.getByLabelText('Animals'), csvFile('animals.csv'));
+    await userEvent.upload(canvas.getByLabelText('Appointments'), csvFile('appointments.csv'));
+    await userEvent.click(canvas.getByRole('button', { name: 'Run migration audit' }));
+
+    await waitFor(() => expect(canvas.getByText(/Reading the uploaded files/)).toBeInTheDocument());
+    await waitFor(() => expect(canvas.getByText('Findings (1)')).toBeInTheDocument(), {
+      timeout: 10_000,
+    });
+    await expect(canvas.getByText('Row 2')).toBeInTheDocument();
+  },
+};
+
+export const UploadFails: Story = {
+  name: 'Upload request fails',
+  beforeEach: setup((config) => {
+    if (config.method?.toLowerCase() === 'post' && (config.url ?? '').endsWith('/upload-url')) {
+      return { status: 500, body: { message: 'Internal Server Error' } };
+    }
+    return { body: [] };
+  }),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.upload(await canvas.findByLabelText('Owners'), csvFile('owners.csv'));
+    await userEvent.upload(canvas.getByLabelText('Animals'), csvFile('animals.csv'));
+    await userEvent.upload(canvas.getByLabelText('Appointments'), csvFile('appointments.csv'));
+    await userEvent.click(canvas.getByRole('button', { name: 'Run migration audit' }));
+
+    await waitFor(() =>
+      expect(
+        canvas.getByText('Could not start the migration audit. Please try again.')
+      ).toBeInTheDocument()
+    );
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.tsx
@@ -23,7 +23,14 @@ import './MigrationAudit.css';
 import '@/app/features/organizations/styles/Organizations.css';
 
 export const POLL_INTERVAL_MS = 2000;
-const REQUIRED_ROLES = MIGRATION_AUDIT_SECTIONS.filter((s) => s.required).map((s) => s.role);
+const getRequiredRoles = (): MigrationAuditFileRole[] => {
+  const roles: MigrationAuditFileRole[] = [];
+  for (const section of MIGRATION_AUDIT_SECTIONS) {
+    if (section.required) roles.push(section.role);
+  }
+  return roles;
+};
+const REQUIRED_ROLES = getRequiredRoles();
 
 const isTerminal = (status: MigrationAuditRun['status']) =>
   status === 'COMPLETED' || status === 'FAILED';
@@ -57,7 +64,7 @@ const MigrationAudit = () => {
   useEffect(() => {
     if (!primaryOrgId || !run || isTerminal(run.status)) return;
 
-    pollTimer.current = setInterval(async () => {
+    const interval = setInterval(async () => {
       try {
         const refreshed = await getMigrationAuditRun(primaryOrgId, run.id);
         setRun(refreshed);
@@ -66,8 +73,12 @@ const MigrationAudit = () => {
         logger.error('Failed to poll migration audit run', err);
       }
     }, POLL_INTERVAL_MS);
+    pollTimer.current = interval;
 
-    return stopPolling;
+    return () => {
+      clearInterval(interval);
+      if (pollTimer.current === interval) pollTimer.current = null;
+    };
     // eslint-disable-next-line react-hooks/exhaustive-deps -- re-runs only on run id/status transitions, not every `run` update the poll itself produces
   }, [primaryOrgId, run?.id, run?.status, stopPolling]);
 
@@ -90,14 +101,21 @@ const MigrationAudit = () => {
     setSubmitting(true);
     setError(null);
     try {
-      const sourceKeys: Partial<Record<MigrationAuditFileRole, string>> = {};
-      for (const section of MIGRATION_AUDIT_SECTIONS) {
+      const uploads = MIGRATION_AUDIT_SECTIONS.flatMap((section) => {
         const file = files[section.role];
-        if (!file) continue;
-        const { url, key } = await getMigrationAuditUploadUrl(primaryOrgId);
-        await uploadMigrationAuditFile(url, file);
-        sourceKeys[section.role] = key;
-      }
+        if (!file) return [];
+        return [{ role: section.role, file }];
+      });
+      const uploadedFiles = await Promise.all(
+        uploads.map(async ({ role, file }) => {
+          const { url, key } = await getMigrationAuditUploadUrl(primaryOrgId);
+          await uploadMigrationAuditFile(url, file);
+          return [role, key] as const;
+        })
+      );
+      const sourceKeys = Object.fromEntries(uploadedFiles) as Partial<
+        Record<MigrationAuditFileRole, string>
+      >;
 
       const created = await createMigrationAuditRun(primaryOrgId, sourceKeys);
       setRun({

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.tsx
@@ -36,6 +36,27 @@ const isTerminal = (status: MigrationAuditRun['status']) =>
   status === 'COMPLETED' || status === 'FAILED';
 
 /**
+ * The chosen files, the run and the error banner all belong to the
+ * organisation they were produced for, so they carry that organisation's id
+ * and are read back through it. Switching organisations must never leave the
+ * previous one's report on screen, nor keep polling its run id through the
+ * newly selected organisation's endpoint.
+ */
+type AuditState = {
+  orgId: string | null;
+  files: Partial<Record<MigrationAuditFileRole, File>>;
+  run: MigrationAuditRun | null;
+  error: string | null;
+};
+
+const emptyState = (orgId: string | null): AuditState => ({
+  orgId,
+  files: {},
+  run: null,
+  error: null,
+});
+
+/**
  * Review surface for #3056's read-only migration-audit API: upload the
  * source CSVs directly to S3 via presigned URLs, create the run, poll until
  * it leaves PENDING/RUNNING, then hand the result to MigrationAuditReview.
@@ -46,11 +67,17 @@ const isTerminal = (status: MigrationAuditRun['status']) =>
 const MigrationAudit = () => {
   const primaryOrgId = useOrgStore((state) => state.primaryOrgId);
 
-  const [files, setFiles] = useState<Partial<Record<MigrationAuditFileRole, File>>>({});
   const [submitting, setSubmitting] = useState(false);
-  const [run, setRun] = useState<MigrationAuditRun | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  const [stored, setStored] = useState<AuditState>(() => emptyState(primaryOrgId));
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // React re-renders before committing a state update made during render, so
+  // another organisation's leftovers are dropped without ever painting and
+  // without the effects below ever seeing them.
+  if (stored.orgId !== primaryOrgId) {
+    setStored(emptyState(primaryOrgId));
+  }
+  const { files, run, error } = stored;
 
   const stopPolling = useCallback(() => {
     if (pollTimer.current !== null) {
@@ -63,11 +90,13 @@ const MigrationAudit = () => {
 
   useEffect(() => {
     if (!primaryOrgId || !run || isTerminal(run.status)) return;
+    const orgId = primaryOrgId;
+    const runId = run.id;
 
     const interval = setInterval(async () => {
       try {
-        const refreshed = await getMigrationAuditRun(primaryOrgId, run.id);
-        setRun(refreshed);
+        const refreshed = await getMigrationAuditRun(orgId, runId);
+        setStored((prev) => (prev.orgId === orgId ? { ...prev, run: refreshed } : prev));
         if (isTerminal(refreshed.status)) stopPolling();
       } catch (err) {
         logger.error('Failed to poll migration audit run', err);
@@ -83,32 +112,34 @@ const MigrationAudit = () => {
   }, [primaryOrgId, run?.id, run?.status, stopPolling]);
 
   const handleFileChange = (role: MigrationAuditFileRole, file: File | null) => {
-    setFiles((prev) => {
-      const next = { ...prev };
-      if (file) {
-        next[role] = file;
-      } else {
-        delete next[role];
-      }
-      return next;
-    });
+    const next = { ...files };
+    if (file) {
+      next[role] = file;
+    } else {
+      delete next[role];
+    }
+    setStored({ orgId: primaryOrgId, files: next, run, error });
   };
 
   const canSubmit = REQUIRED_ROLES.every((role) => Boolean(files[role]));
 
   const handleSubmit = async () => {
     if (!primaryOrgId || !canSubmit) return;
+    // Everything this submit writes back is tagged with the organisation it
+    // was started for, so a switch mid-upload leaves the result inert.
+    const orgId = primaryOrgId;
+    const submittedFiles = files;
     setSubmitting(true);
-    setError(null);
+    setStored({ orgId, files: submittedFiles, run: null, error: null });
     try {
       const uploads = MIGRATION_AUDIT_SECTIONS.flatMap((section) => {
-        const file = files[section.role];
+        const file = submittedFiles[section.role];
         if (!file) return [];
         return [{ role: section.role, file }];
       });
       const uploadedFiles = await Promise.all(
         uploads.map(async ({ role, file }) => {
-          const { url, key } = await getMigrationAuditUploadUrl(primaryOrgId);
+          const { url, key } = await getMigrationAuditUploadUrl(orgId);
           await uploadMigrationAuditFile(url, file);
           return [role, key] as const;
         })
@@ -117,19 +148,29 @@ const MigrationAudit = () => {
         Record<MigrationAuditFileRole, string>
       >;
 
-      const created = await createMigrationAuditRun(primaryOrgId, sourceKeys);
-      setRun({
-        id: created.id,
-        status: created.status,
-        summary: null,
-        errorMessage: null,
-        createdAt: new Date().toISOString(),
-        completedAt: null,
-        outcome: { resourceType: 'OperationOutcome', issue: [] },
+      const created = await createMigrationAuditRun(orgId, sourceKeys);
+      setStored({
+        orgId,
+        files: submittedFiles,
+        error: null,
+        run: {
+          id: created.id,
+          status: created.status,
+          summary: null,
+          errorMessage: null,
+          createdAt: new Date().toISOString(),
+          completedAt: null,
+          outcome: { resourceType: 'OperationOutcome', issue: [] },
+        },
       });
     } catch (err) {
       logger.error('Failed to start migration audit', err);
-      setError('Could not start the migration audit. Please try again.');
+      setStored({
+        orgId,
+        files: submittedFiles,
+        run: null,
+        error: 'Could not start the migration audit. Please try again.',
+      });
     } finally {
       setSubmitting(false);
     }
@@ -137,9 +178,7 @@ const MigrationAudit = () => {
 
   const handleStartNew = () => {
     stopPolling();
-    setRun(null);
-    setFiles({});
-    setError(null);
+    setStored(emptyState(primaryOrgId));
   };
 
   return (

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAudit.tsx
@@ -1,0 +1,168 @@
+'use client';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
+import ProtectedRoute from '@/app/ui/layout/guards/ProtectedRoute';
+import PermissionGate from '@/app/ui/layout/guards/PermissionGate';
+import { PERMISSIONS } from '@/app/lib/permissions';
+import { logger } from '@/app/lib/logger';
+import { useOrgStore } from '@/app/stores/orgStore';
+import {
+  createMigrationAuditRun,
+  getMigrationAuditRun,
+  getMigrationAuditUploadUrl,
+  uploadMigrationAuditFile,
+  type MigrationAuditFileRole,
+  type MigrationAuditRun,
+} from '@/app/features/onboarding/services/migrationAuditService';
+
+import MigrationAuditUploadForm from './MigrationAuditUploadForm';
+import MigrationAuditReview from './MigrationAuditReview';
+import { MIGRATION_AUDIT_SECTIONS } from './migrationAuditSchema';
+
+import './MigrationAudit.css';
+import '@/app/features/organizations/styles/Organizations.css';
+
+export const POLL_INTERVAL_MS = 2000;
+const REQUIRED_ROLES = MIGRATION_AUDIT_SECTIONS.filter((s) => s.required).map((s) => s.role);
+
+const isTerminal = (status: MigrationAuditRun['status']) =>
+  status === 'COMPLETED' || status === 'FAILED';
+
+/**
+ * Review surface for #3056's read-only migration-audit API: upload the
+ * source CSVs directly to S3 via presigned URLs, create the run, poll until
+ * it leaves PENDING/RUNNING, then hand the result to MigrationAuditReview.
+ * Owns the upload/create/poll requests; the upload form and the review are
+ * separate presentational components, same split as
+ * DeveloperFormDraftImport/DraftImportForm/DraftImportReview (#3060).
+ */
+const MigrationAudit = () => {
+  const primaryOrgId = useOrgStore((state) => state.primaryOrgId);
+
+  const [files, setFiles] = useState<Partial<Record<MigrationAuditFileRole, File>>>({});
+  const [submitting, setSubmitting] = useState(false);
+  const [run, setRun] = useState<MigrationAuditRun | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopPolling = useCallback(() => {
+    if (pollTimer.current !== null) {
+      clearInterval(pollTimer.current);
+      pollTimer.current = null;
+    }
+  }, []);
+
+  useEffect(() => stopPolling, [stopPolling]);
+
+  useEffect(() => {
+    if (!primaryOrgId || !run || isTerminal(run.status)) return;
+
+    pollTimer.current = setInterval(async () => {
+      try {
+        const refreshed = await getMigrationAuditRun(primaryOrgId, run.id);
+        setRun(refreshed);
+        if (isTerminal(refreshed.status)) stopPolling();
+      } catch (err) {
+        logger.error('Failed to poll migration audit run', err);
+      }
+    }, POLL_INTERVAL_MS);
+
+    return stopPolling;
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- re-runs only on run id/status transitions, not every `run` update the poll itself produces
+  }, [primaryOrgId, run?.id, run?.status, stopPolling]);
+
+  const handleFileChange = (role: MigrationAuditFileRole, file: File | null) => {
+    setFiles((prev) => {
+      const next = { ...prev };
+      if (file) {
+        next[role] = file;
+      } else {
+        delete next[role];
+      }
+      return next;
+    });
+  };
+
+  const canSubmit = REQUIRED_ROLES.every((role) => Boolean(files[role]));
+
+  const handleSubmit = async () => {
+    if (!primaryOrgId || !canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const sourceKeys: Partial<Record<MigrationAuditFileRole, string>> = {};
+      for (const section of MIGRATION_AUDIT_SECTIONS) {
+        const file = files[section.role];
+        if (!file) continue;
+        const { url, key } = await getMigrationAuditUploadUrl(primaryOrgId);
+        await uploadMigrationAuditFile(url, file);
+        sourceKeys[section.role] = key;
+      }
+
+      const created = await createMigrationAuditRun(primaryOrgId, sourceKeys);
+      setRun({
+        id: created.id,
+        status: created.status,
+        summary: null,
+        errorMessage: null,
+        createdAt: new Date().toISOString(),
+        completedAt: null,
+        outcome: { resourceType: 'OperationOutcome', issue: [] },
+      });
+    } catch (err) {
+      logger.error('Failed to start migration audit', err);
+      setError('Could not start the migration audit. Please try again.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  const handleStartNew = () => {
+    stopPolling();
+    setRun(null);
+    setFiles({});
+    setError(null);
+  };
+
+  return (
+    <ProtectedRoute>
+      <PermissionGate
+        anyOf={[PERMISSIONS.ORG_ONBOARDING]}
+        deniedResource="Migration audit"
+        orgId={primaryOrgId}
+      >
+        <div className="OperationsWrapper">
+          <div className="TitleContainer">
+            <h1 className="text-heading-1 text-text-primary">Migration audit</h1>
+          </div>
+
+          <p className="text-body-3 text-text-secondary MigrationAudit-intro">
+            Upload the owners, animals and appointments CSVs exported from your previous system
+            (attachments optional) to preview what would come across - counts, and every missing,
+            duplicate or orphaned record - before deciding whether to proceed with an import.
+          </p>
+
+          {error && (
+            <p className="text-body-3 MigrationAudit-error" role="alert">
+              {error}
+            </p>
+          )}
+
+          {!run && (
+            <MigrationAuditUploadForm
+              files={files}
+              onFileChange={handleFileChange}
+              submitting={submitting}
+              canSubmit={canSubmit}
+              onSubmit={handleSubmit}
+            />
+          )}
+
+          {run && <MigrationAuditReview run={run} onStartNew={handleStartNew} />}
+        </div>
+      </PermissionGate>
+    </ProtectedRoute>
+  );
+};
+
+export default MigrationAudit;

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditReview.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditReview.stories.tsx
@@ -1,0 +1,138 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import MigrationAuditReview from './MigrationAuditReview';
+import type { MigrationAuditRun } from '@/app/features/onboarding/services/migrationAuditService';
+
+const BASE_RUN: MigrationAuditRun = {
+  id: 'run1',
+  status: 'PENDING',
+  summary: null,
+  errorMessage: null,
+  createdAt: '2026-09-12T00:00:00.000Z',
+  completedAt: null,
+  outcome: { resourceType: 'OperationOutcome', issue: [] },
+};
+
+const COMPLETED_RUN: MigrationAuditRun = {
+  ...BASE_RUN,
+  status: 'COMPLETED',
+  completedAt: '2026-09-12T00:00:05.000Z',
+  summary: {
+    OWNERS: { status: 'ASSESSED', totalRows: 42, duplicateIdentifiers: 1, orphanReferences: 0 },
+    ANIMALS: { status: 'ASSESSED', totalRows: 58, duplicateIdentifiers: 0, orphanReferences: 2 },
+    APPOINTMENTS: {
+      status: 'ASSESSED',
+      totalRows: 130,
+      duplicateIdentifiers: 0,
+      orphanReferences: 0,
+    },
+    ATTACHMENTS: {
+      status: 'NOT_ASSESSED',
+      notAssessedReason: 'file_not_provided',
+      totalRows: 0,
+      duplicateIdentifiers: 0,
+      orphanReferences: 0,
+    },
+  },
+  outcome: {
+    resourceType: 'OperationOutcome',
+    issue: [
+      {
+        severity: 'error',
+        code: 'orphan_reference',
+        diagnostics: 'animals.csv row 12 references owner_external_id not present in owners.csv.',
+        expression: ['animals.csv[row 12]'],
+      },
+      {
+        severity: 'warning',
+        code: 'duplicate_identifier',
+        diagnostics: 'owners.csv row 30 repeats external_id already seen at row 4.',
+        expression: ['owners.csv[row 30]'],
+      },
+      {
+        severity: 'information',
+        code: 'attachment_manifest_not_provided',
+        diagnostics: 'No attachment manifest was provided; attachments were not assessed.',
+        expression: ['attachments.csv'],
+      },
+    ],
+  },
+};
+
+const meta = {
+  title: 'Onboarding/MigrationAuditReview',
+  component: MigrationAuditReview,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          "Renders one migration-audit run (#3056's read-only API): in-flight while " +
+          'PENDING/RUNNING, the failure reason on FAILED, and on COMPLETED the per-section ' +
+          'summary plus every finding grouped by source file and severity.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    run: BASE_RUN,
+    onStartNew: fn(),
+  },
+} satisfies Meta<typeof MigrationAuditReview>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const InProgress: Story = {
+  name: 'PENDING/RUNNING - no restart action yet',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('status')).toHaveTextContent(/Reading the uploaded files/);
+    await expect(
+      canvas.queryByRole('button', { name: 'Start a new audit' })
+    ).not.toBeInTheDocument();
+  },
+};
+
+export const Failed: Story = {
+  name: 'Run failed - shows the reason and offers a restart',
+  args: {
+    run: { ...BASE_RUN, status: 'FAILED', errorMessage: 'owners.csv could not be parsed as CSV.' },
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByRole('alert')).toHaveTextContent(
+      'owners.csv could not be parsed as CSV.'
+    );
+    await userEvent.click(canvas.getByRole('button', { name: 'Start a new audit' }));
+    await expect(args.onStartNew).toHaveBeenCalled();
+  },
+};
+
+export const Completed: Story = {
+  name: 'Completed - per-section summary and grouped findings',
+  args: { run: COMPLETED_RUN },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Findings (3)')).toBeInTheDocument();
+    await expect(canvas.getByText('Not assessed (file_not_provided).')).toBeInTheDocument();
+    await expect(canvas.getByText('Row 12')).toBeInTheDocument();
+    await expect(canvas.getByText('information')).toBeInTheDocument();
+  },
+};
+
+export const CompletedNoFindings: Story = {
+  name: 'Completed - no findings',
+  args: {
+    run: {
+      ...COMPLETED_RUN,
+      outcome: { resourceType: 'OperationOutcome', issue: [] },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('Findings (0)')).toBeInTheDocument();
+    await expect(canvas.getByText(/No findings/)).toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditReview.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditReview.tsx
@@ -149,13 +149,11 @@ const MigrationAuditReview = ({ run, onStartNew }: MigrationAuditReviewProps) =>
                   {file}
                 </h3>
                 <ul className="MigrationAudit-findingList">
-                  {issues.map((issue, index) => {
+                  {issues.map((issue) => {
                     const row = rowFor(issue);
+                    const issueKey = JSON.stringify(issue);
                     return (
-                      <li
-                        key={`${file}-${index}`}
-                        data-testid={`migration-audit-finding-${file}-${index}`}
-                      >
+                      <li key={issueKey}>
                         <StatusPill label={issue.severity} tone={severityTone(issue.severity)} />
                         {row && <span className="MigrationAudit-findingRow">Row {row}</span>}
                         <p className="text-body-3 text-text-secondary">{issue.diagnostics}</p>

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditReview.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditReview.tsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import type { OperationOutcomeIssue } from '@yosemite-crew/fhir';
+
+import { Secondary } from '@/app/ui/primitives/Buttons';
+import StatusPill, { type StatusTone } from '@/app/ui/primitives/StatusPill/StatusPill';
+import type {
+  MigrationAuditRun,
+  MigrationAuditSectionName,
+} from '@/app/features/onboarding/services/migrationAuditService';
+import { MIGRATION_AUDIT_SECTION_LABELS } from './migrationAuditSchema';
+
+const SECTION_ORDER: MigrationAuditSectionName[] = [
+  'OWNERS',
+  'ANIMALS',
+  'APPOINTMENTS',
+  'ATTACHMENTS',
+];
+const SOURCE_FILE_ORDER = ['owners.csv', 'animals.csv', 'appointments.csv', 'attachments.csv'];
+const SEVERITY_ORDER = ['fatal', 'error', 'warning', 'information'];
+const ROW_EXPRESSION = /\[row (\d+)]/;
+
+const severityTone = (severity: string): StatusTone => {
+  if (severity === 'fatal' || severity === 'error') return 'danger';
+  if (severity === 'warning') return 'warning';
+  return 'info';
+};
+
+/** `expression[0]` is e.g. "owners.csv" or "owners.csv[row 5]" - the file name without a row suffix. */
+const sourceFileFor = (issue: OperationOutcomeIssue): string => {
+  const expression = issue.expression?.[0] ?? 'unknown';
+  const bracket = expression.indexOf('[');
+  return bracket === -1 ? expression : expression.slice(0, bracket);
+};
+
+const rowFor = (issue: OperationOutcomeIssue): string | null => {
+  const match = ROW_EXPRESSION.exec(issue.expression?.[0] ?? '');
+  return match ? match[1] : null;
+};
+
+const bySourceFileOrder = (a: string, b: string): number => {
+  const indexOf = (file: string) => {
+    const index = SOURCE_FILE_ORDER.indexOf(file);
+    return index === -1 ? SOURCE_FILE_ORDER.length : index;
+  };
+  return indexOf(a) - indexOf(b);
+};
+
+export interface MigrationAuditReviewProps {
+  run: MigrationAuditRun;
+  /** Absent while a run is in flight - there is nothing to restart yet. */
+  onStartNew?: () => void;
+}
+
+/**
+ * Renders one migration-audit run (#3056's read-only API): the in-flight
+ * state while PENDING/RUNNING, the failure reason on FAILED, and on
+ * COMPLETED the per-section summary plus every finding grouped by source
+ * file and severity - never collapsed to a count, so a practice owner can
+ * see exactly which row needs attention before deciding to proceed.
+ */
+const MigrationAuditReview = ({ run, onStartNew }: MigrationAuditReviewProps) => {
+  if (run.status === 'PENDING' || run.status === 'RUNNING') {
+    return (
+      <output className="MigrationAudit-progress yc-card-surface">
+        <p className="text-body-2 text-text-primary">
+          Reading the uploaded files and checking for missing, duplicate and orphaned records…
+        </p>
+      </output>
+    );
+  }
+
+  if (run.status === 'FAILED') {
+    return (
+      <div className="MigrationAudit-failed yc-card-surface" role="alert">
+        <h2 className="text-heading-3 text-text-primary">Migration audit failed</h2>
+        <p className="text-body-3 text-text-secondary">
+          {run.errorMessage ?? 'The audit could not be completed. Please try again.'}
+        </p>
+        {onStartNew && <Secondary text="Start a new audit" onClick={onStartNew} />}
+      </div>
+    );
+  }
+
+  const issuesBySourceFile = new Map<string, OperationOutcomeIssue[]>();
+  for (const issue of run.outcome.issue) {
+    const file = sourceFileFor(issue);
+    const existing = issuesBySourceFile.get(file);
+    if (existing) {
+      existing.push(issue);
+    } else {
+      issuesBySourceFile.set(file, [issue]);
+    }
+  }
+  const orderedFiles = [...issuesBySourceFile.keys()].sort(bySourceFileOrder);
+
+  return (
+    <div className="MigrationAudit-review">
+      <div className="MigrationAudit-summaryGrid">
+        {SECTION_ORDER.filter((section) => run.summary?.[section]).map((section) => {
+          const summary = run.summary![section]!;
+          return (
+            <div key={section} className="MigrationAudit-summaryCard yc-card-surface">
+              <h2 className="text-heading-3 text-text-primary">
+                {MIGRATION_AUDIT_SECTION_LABELS[section]}
+              </h2>
+              {summary.status === 'NOT_ASSESSED' ? (
+                <p className="text-body-3 text-text-secondary">
+                  Not assessed
+                  {summary.notAssessedReason ? ` (${summary.notAssessedReason})` : ''}.
+                </p>
+              ) : (
+                <dl className="MigrationAudit-summaryStats">
+                  <div>
+                    <dt className="text-caption-2 text-text-tertiary">Rows</dt>
+                    <dd className="text-body-2 text-text-primary">{summary.totalRows}</dd>
+                  </div>
+                  <div>
+                    <dt className="text-caption-2 text-text-tertiary">Duplicates</dt>
+                    <dd className="text-body-2 text-text-primary">
+                      {summary.duplicateIdentifiers}
+                    </dd>
+                  </div>
+                  <div>
+                    <dt className="text-caption-2 text-text-tertiary">Orphan references</dt>
+                    <dd className="text-body-2 text-text-primary">{summary.orphanReferences}</dd>
+                  </div>
+                </dl>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <section className="MigrationAudit-findings yc-card-surface">
+        <h2 className="text-heading-3 text-text-primary">Findings ({run.outcome.issue.length})</h2>
+        {run.outcome.issue.length === 0 ? (
+          <p className="text-body-3 text-text-secondary">
+            No findings - every required file was assessed with no missing, duplicate or orphaned
+            records.
+          </p>
+        ) : (
+          orderedFiles.map((file) => {
+            const issues = [...(issuesBySourceFile.get(file) ?? [])].sort(
+              (a, b) => SEVERITY_ORDER.indexOf(a.severity) - SEVERITY_ORDER.indexOf(b.severity)
+            );
+            return (
+              <div key={file} className="MigrationAudit-findingGroup">
+                <h3 className="text-body-2 text-text-primary MigrationAudit-findingGroupTitle">
+                  {file}
+                </h3>
+                <ul className="MigrationAudit-findingList">
+                  {issues.map((issue, index) => {
+                    const row = rowFor(issue);
+                    return (
+                      <li
+                        key={`${file}-${index}`}
+                        data-testid={`migration-audit-finding-${file}-${index}`}
+                      >
+                        <StatusPill label={issue.severity} tone={severityTone(issue.severity)} />
+                        {row && <span className="MigrationAudit-findingRow">Row {row}</span>}
+                        <p className="text-body-3 text-text-secondary">{issue.diagnostics}</p>
+                      </li>
+                    );
+                  })}
+                </ul>
+              </div>
+            );
+          })
+        )}
+      </section>
+
+      {onStartNew && <Secondary text="Start a new audit" onClick={onStartNew} />}
+    </div>
+  );
+};
+
+export default MigrationAuditReview;

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditUploadForm.stories.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditUploadForm.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { expect, fn, userEvent, within } from 'storybook/test';
+
+import MigrationAuditUploadForm from './MigrationAuditUploadForm';
+
+const csvFile = (name: string) => new File(['external_id\n1'], name, { type: 'text/csv' });
+
+const meta = {
+  title: 'Onboarding/MigrationAuditUploadForm',
+  component: MigrationAuditUploadForm,
+  parameters: {
+    layout: 'padded',
+    docs: {
+      description: {
+        component:
+          'The migration-audit upload step (#3057): one CSV per section (owners/animals/' +
+          'appointments required, attachments optional), with the published column list and ' +
+          'size/row limits shown up front since #3056 publishes no metadata endpoint for them.',
+      },
+    },
+  },
+  tags: ['autodocs'],
+  args: {
+    files: {},
+    onFileChange: fn(),
+    submitting: false,
+    canSubmit: false,
+    onSubmit: fn(),
+  },
+} satisfies Meta<typeof MigrationAuditUploadForm>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Empty: Story = {
+  name: 'No files chosen yet - submit disabled',
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/up to 5 MB and 5,000 rows/)).toBeInTheDocument();
+    await expect(canvas.getAllByText('Required')).toHaveLength(3);
+    await expect(canvas.getByText('Optional')).toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Run migration audit' })).toBeDisabled();
+  },
+};
+
+export const ChooseFile: Story = {
+  name: 'Choosing a file reports it to the container',
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.upload(canvas.getByLabelText('Owners'), csvFile('owners.csv'));
+    await expect(args.onFileChange).toHaveBeenCalledWith(
+      'owners',
+      expect.objectContaining({ name: 'owners.csv' })
+    );
+  },
+};
+
+export const ReadyToSubmit: Story = {
+  name: 'Every required file chosen - submit enabled',
+  args: {
+    files: {
+      owners: csvFile('owners.csv'),
+      animals: csvFile('animals.csv'),
+      appointments: csvFile('appointments.csv'),
+    },
+    canSubmit: true,
+  },
+  play: async ({ args, canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText('owners.csv')).toBeInTheDocument();
+    await userEvent.click(canvas.getByRole('button', { name: 'Run migration audit' }));
+    await expect(args.onSubmit).toHaveBeenCalled();
+  },
+};
+
+export const Uploading: Story = {
+  name: 'Uploading - inputs disabled',
+  args: {
+    files: { owners: csvFile('owners.csv') },
+    submitting: true,
+    canSubmit: true,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByLabelText('Owners')).toBeDisabled();
+    await expect(canvas.getByRole('button', { name: 'Uploading…' })).toBeDisabled();
+  },
+};

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditUploadForm.tsx
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/MigrationAuditUploadForm.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+
+import { Primary } from '@/app/ui/primitives/Buttons';
+import type { MigrationAuditFileRole } from '@/app/features/onboarding/services/migrationAuditService';
+import { MIGRATION_AUDIT_LIMITS, MIGRATION_AUDIT_SECTIONS } from './migrationAuditSchema';
+
+const formatMegabytes = (bytes: number): string => `${Math.round(bytes / (1024 * 1024))} MB`;
+
+export interface MigrationAuditUploadFormProps {
+  files: Partial<Record<MigrationAuditFileRole, File>>;
+  onFileChange: (role: MigrationAuditFileRole, file: File | null) => void;
+  submitting: boolean;
+  canSubmit: boolean;
+  onSubmit: () => void;
+}
+
+/**
+ * The upload step: one CSV per section (owners/animals/appointments required,
+ * attachments optional), with the published column list and size/row limits
+ * shown up front - #3057's own acceptance criterion, since #3056 publishes no
+ * metadata endpoint for them.
+ */
+const MigrationAuditUploadForm = ({
+  files,
+  onFileChange,
+  submitting,
+  canSubmit,
+  onSubmit,
+}: MigrationAuditUploadFormProps) => (
+  <div className="MigrationAudit-upload yc-card-surface">
+    <p className="text-body-3 text-text-secondary MigrationAudit-limits">
+      Each file is a CSV, up to {formatMegabytes(MIGRATION_AUDIT_LIMITS.maxFileBytes)} and{' '}
+      {MIGRATION_AUDIT_LIMITS.maxRowsPerFile.toLocaleString()} rows. Columns outside the supported
+      set are reported as findings, never silently dropped.
+    </p>
+
+    <div className="MigrationAudit-fileList">
+      {MIGRATION_AUDIT_SECTIONS.map((section) => {
+        const inputId = `migration-audit-file-${section.role}`;
+        const selected = files[section.role];
+        return (
+          <div key={section.role} className="MigrationAudit-fileRow">
+            <div className="MigrationAudit-fileHeading">
+              <label htmlFor={inputId} className="text-body-2 text-text-primary">
+                {section.label}
+              </label>
+              <span
+                className={`MigrationAudit-badge ${
+                  section.required
+                    ? 'MigrationAudit-badge--required'
+                    : 'MigrationAudit-badge--optional'
+                }`}
+              >
+                {section.required ? 'Required' : 'Optional'}
+              </span>
+            </div>
+            <p className="text-caption-2 text-text-tertiary MigrationAudit-columns">
+              Columns: {section.columns.join(', ')}
+            </p>
+            <input
+              id={inputId}
+              type="file"
+              accept=".csv,text/csv"
+              onChange={(event) => onFileChange(section.role, event.target.files?.[0] ?? null)}
+              disabled={submitting}
+            />
+            {selected && (
+              <p
+                className="text-caption-2 text-text-secondary"
+                data-testid={`migration-audit-selected-${section.role}`}
+              >
+                {selected.name}
+              </p>
+            )}
+          </div>
+        );
+      })}
+    </div>
+
+    <Primary
+      text={submitting ? 'Uploading…' : 'Run migration audit'}
+      onClick={onSubmit}
+      isDisabled={submitting || !canSubmit}
+      type="button"
+    />
+  </div>
+);
+
+export default MigrationAuditUploadForm;

--- a/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/migrationAuditSchema.ts
+++ b/apps/frontend/src/app/features/onboarding/pages/MigrationAudit/migrationAuditSchema.ts
@@ -1,0 +1,55 @@
+import type { MigrationAuditFileRole } from '@/app/features/onboarding/services/migrationAuditService';
+
+export interface MigrationAuditSectionSchema {
+  role: MigrationAuditFileRole;
+  label: string;
+  required: boolean;
+  columns: readonly string[];
+}
+
+/**
+ * #3056's backend (apps/backend/src/services/migration-audit-plan.ts) is the
+ * source of truth for these columns and limits, and publishes no metadata
+ * endpoint for them (out of scope for #3057 - "no new backend endpoint"). This
+ * is the UI's own copy for the "published per-section column list and
+ * row/bytes limits shown up front" requirement; keep the two in sync if the
+ * backend planner's supported columns or limits change.
+ */
+export const MIGRATION_AUDIT_SECTIONS: readonly MigrationAuditSectionSchema[] = [
+  {
+    role: 'owners',
+    label: 'Owners',
+    required: true,
+    columns: ['external_id', 'first_name', 'last_name', 'email', 'phone'],
+  },
+  {
+    role: 'animals',
+    label: 'Animals',
+    required: true,
+    columns: ['external_id', 'owner_external_id', 'name', 'species', 'date_of_birth'],
+  },
+  {
+    role: 'appointments',
+    label: 'Appointments',
+    required: true,
+    columns: ['external_id', 'animal_external_id', 'owner_external_id', 'date', 'reason'],
+  },
+  {
+    role: 'attachments',
+    label: 'Attachments',
+    required: false,
+    columns: ['external_id', 'animal_external_id', 'filename', 'sha256'],
+  },
+];
+
+export const MIGRATION_AUDIT_LIMITS = {
+  maxFileBytes: 5 * 1024 * 1024,
+  maxRowsPerFile: 5000,
+} as const;
+
+export const MIGRATION_AUDIT_SECTION_LABELS: Record<string, string> = {
+  OWNERS: 'Owners',
+  ANIMALS: 'Animals',
+  APPOINTMENTS: 'Appointments',
+  ATTACHMENTS: 'Attachments',
+};

--- a/apps/frontend/src/app/features/onboarding/services/migrationAuditService.ts
+++ b/apps/frontend/src/app/features/onboarding/services/migrationAuditService.ts
@@ -1,0 +1,72 @@
+import axios from 'axios';
+import { getData, postData } from '@/app/services/axios';
+import type { OperationOutcome } from '@yosemite-crew/fhir';
+
+export type MigrationAuditFileRole = 'owners' | 'animals' | 'appointments' | 'attachments';
+
+export type MigrationAuditRunStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'FAILED';
+
+export type MigrationAuditSectionName = 'OWNERS' | 'ANIMALS' | 'APPOINTMENTS' | 'ATTACHMENTS';
+
+export interface MigrationAuditSectionSummary {
+  status: 'ASSESSED' | 'NOT_ASSESSED';
+  notAssessedReason?: string;
+  totalRows: number;
+  duplicateIdentifiers: number;
+  orphanReferences: number;
+}
+
+export interface MigrationAuditRun {
+  id: string;
+  status: MigrationAuditRunStatus;
+  summary: Partial<Record<MigrationAuditSectionName, MigrationAuditSectionSummary>> | null;
+  errorMessage: string | null;
+  createdAt: string;
+  completedAt: string | null;
+  outcome: OperationOutcome;
+}
+
+const runsBase = (organisationId: string) =>
+  `/v1/migration-audit/pms/organisations/${organisationId}/migration-audit`;
+
+export const getMigrationAuditUploadUrl = async (
+  organisationId: string
+): Promise<{ url: string; key: string }> => {
+  const res = await postData<{ url: string; key: string }>(
+    `${runsBase(organisationId)}/upload-url`
+  );
+  return res.data;
+};
+
+/**
+ * The presigned URL's signature is bound to a fixed `text/csv` content type
+ * (mintMigrationAuditUploadUrl on the backend always signs it that way) - the
+ * browser's own guess at `file.type` for a .csv file is not guaranteed to
+ * match, which would fail the S3 PUT with a signature mismatch. Send the
+ * exact value that was signed, not the file's reported type.
+ */
+export const uploadMigrationAuditFile = async (uploadUrl: string, file: File): Promise<void> => {
+  await axios.put(uploadUrl, file, {
+    headers: { 'Content-Type': 'text/csv' },
+    withCredentials: false,
+  });
+};
+
+export const createMigrationAuditRun = async (
+  organisationId: string,
+  sourceKeys: Partial<Record<MigrationAuditFileRole, string>>
+): Promise<{ id: string; status: MigrationAuditRunStatus }> => {
+  const res = await postData<{ id: string; status: MigrationAuditRunStatus }>(
+    runsBase(organisationId),
+    { sourceKeys }
+  );
+  return res.data;
+};
+
+export const getMigrationAuditRun = async (
+  organisationId: string,
+  auditRunId: string
+): Promise<MigrationAuditRun> => {
+  const res = await getData<MigrationAuditRun>(`${runsBase(organisationId)}/${auditRunId}`);
+  return res.data;
+};

--- a/apps/frontend/src/app/features/onboarding/services/migrationAuditService.ts
+++ b/apps/frontend/src/app/features/onboarding/services/migrationAuditService.ts
@@ -1,5 +1,5 @@
-import axios from 'axios';
 import { getData, postData } from '@/app/services/axios';
+import { uploadFileToS3 } from '@/app/features/inventory/services/inventoryUploadService';
 import type { OperationOutcome } from '@yosemite-crew/fhir';
 
 export type MigrationAuditFileRole = 'owners' | 'animals' | 'appointments' | 'attachments';
@@ -26,8 +26,28 @@ export interface MigrationAuditRun {
   outcome: OperationOutcome;
 }
 
-const runsBase = (organisationId: string) =>
-  `/v1/migration-audit/pms/organisations/${organisationId}/migration-audit`;
+const assertPathId = (value: string, label: string): string => {
+  if (!/^[A-Za-z0-9_-]+$/.test(value)) throw new Error(`Invalid ${label} ID`);
+  return value;
+};
+
+const runsBase = (organisationId: string) => {
+  const safeOrganisationId = assertPathId(organisationId, 'organisation');
+  return `/v1/migration-audit/pms/organisations/${safeOrganisationId}/migration-audit`;
+};
+
+const assertUploadUrl = (value: string): string => {
+  const url = new URL(value);
+  if (
+    url.protocol !== 'https:' ||
+    !url.hostname.endsWith('.amazonaws.com') ||
+    url.username ||
+    url.password
+  ) {
+    throw new Error('Invalid migration audit upload URL');
+  }
+  return url.toString();
+};
 
 export const getMigrationAuditUploadUrl = async (
   organisationId: string
@@ -46,10 +66,12 @@ export const getMigrationAuditUploadUrl = async (
  * exact value that was signed, not the file's reported type.
  */
 export const uploadMigrationAuditFile = async (uploadUrl: string, file: File): Promise<void> => {
-  await axios.put(uploadUrl, file, {
-    headers: { 'Content-Type': 'text/csv' },
-    withCredentials: false,
+  const safeUploadUrl = assertUploadUrl(uploadUrl);
+  const csvFile = new File([file], file.name, {
+    type: 'text/csv',
+    lastModified: file.lastModified,
   });
+  await uploadFileToS3(safeUploadUrl, csvFile);
 };
 
 export const createMigrationAuditRun = async (
@@ -67,6 +89,7 @@ export const getMigrationAuditRun = async (
   organisationId: string,
   auditRunId: string
 ): Promise<MigrationAuditRun> => {
-  const res = await getData<MigrationAuditRun>(`${runsBase(organisationId)}/${auditRunId}`);
+  const safeAuditRunId = assertPathId(auditRunId, 'migration audit run');
+  const res = await getData<MigrationAuditRun>(`${runsBase(organisationId)}/${safeAuditRunId}`);
   return res.data;
 };

--- a/apps/frontend/src/middleware.ts
+++ b/apps/frontend/src/middleware.ts
@@ -42,6 +42,7 @@ const STRICT_CSP_PATH_PREFIXES = [
   '/guides',
   '/integrations',
   '/inventory',
+  '/migration-audit',
   '/network',
   '/organization',
   '/organizations',


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

#3056 shipped the read-only migration-audit API (upload-url mint, run creation, run
retrieval with a FHIR OperationOutcome of findings) with no UI, so it is not usable by the
target persona (a practice owner onboarding from a previous system).

## What is the new behavior?

Adds the frontend review surface at `/migration-audit`, gated on the same `org:onboarding`
permission as other practice-onboarding actions:

- Upload step for the owners/animals/appointments CSVs (attachments optional), publishing
  the supported column list and the row/byte limits up front since #3056 exposes no
  metadata endpoint for them.
- Each file uploads directly to S3 via a presigned URL (same pattern as the existing
  inventory-image upload service); the PUT sends the fixed `text/csv` content type the
  presigned URL was actually signed with, not the browser's guess at the file's mime type.
- Creates the run, then polls the existing GET endpoint every 2s until it leaves
  PENDING/RUNNING.
- Renders the per-section summary (rows / duplicate identifiers / orphan references, or the
  NOT_ASSESSED reason) and every finding grouped by source file and severity. A FAILED run
  shows its reason with an action to start a new audit.

Test plan: `tsc`/`eslint` clean; 4 Jest suites / 20 tests covering the container
(upload -> create -> poll, including a transient poll-error retry and clearing a chosen
file), every run state of the review component, the upload form, and the service layer -
99.8% statement / 93% branch coverage on the new files, mutation-checked. All 10 new
`Onboarding/MigrationAudit*` Storybook stories pass their play functions against a live
Storybook (the container story drives the real component through a stubbed axios adapter);
an axe `heading-order` violation caught during that run (summary cards were `h3` ahead of
the Findings section's `h2`) is fixed by making them `h2` siblings.

## Related Issue(s)

Fixes #3057