### PR TITLE
feat(repo): add companion-scoped visit preparation

### DIFF
--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -21,6 +21,7 @@ import { FinancePaymentService } from "./finance/payment";
 import { resolvePaymentCollectionMethod } from "src/utils/payment";
 import { CompanionOrganisationService } from "./companion-organisation.service";
 import { isSpeciesCompatible } from "./shared/normalize-tokens";
+import { hasCompanionFeature } from "src/middlewares/companion-access";
 
 type AppointmentStatus = AppointmentDomain["status"];
 
@@ -1435,6 +1436,28 @@ const getParentIdFromRow = (row: AppointmentRow): string | undefined => {
   return typeof parentId === "string" && parentId.trim() ? parentId : undefined;
 };
 
+const canParentViewAppointment = async (
+  row: AppointmentRow,
+  parentId: string,
+): Promise<boolean> => {
+  const patientId = getPatientId(row.patient);
+  if (!patientId) return false;
+
+  const link = await prisma.parentPatient.findFirst({
+    where: {
+      parentId,
+      patientId,
+      status: "ACTIVE",
+      role: { in: ["PRIMARY", "CO_PARENT"] },
+    },
+    select: { role: true, permissions: true },
+  });
+
+  return Boolean(
+    link && hasCompanionFeature(link.role, link.permissions, "appointments"),
+  );
+};
+
 const assertParentOwnsAppointment = (row: AppointmentRow, parentId: string) => {
   if (getParentIdFromRow(row) !== parentId) {
     throw new AppointmentPrismaServiceError(
@@ -2513,7 +2536,8 @@ export const AppointmentPrismaService = {
     }
 
     const canViewAsActor = actorId && canViewOwnAppointment(row, actorId);
-    const canViewAsParent = parentId && getParentIdFromRow(row) === parentId;
+    const canViewAsParent =
+      parentId && (await canParentViewAppointment(row, parentId));
 
     if ((actorId || parentId) && !canViewAsActor && !canViewAsParent) {
       throw new AppointmentPrismaServiceError("Appointment not found", 404);

--- a/apps/backend/src/services/form.service.ts
+++ b/apps/backend/src/services/form.service.ts
@@ -29,6 +29,7 @@ import {
 } from "@prisma/client";
 import { prisma } from "src/config/prisma";
 import { TemplateService } from "src/services/template.service";
+import { hasCompanionFeature } from "src/middlewares/companion-access";
 
 export class FormServiceError extends Error {
   constructor(
@@ -505,12 +506,10 @@ const assertTemplateSubmittableByParent = async (params: {
       select: { patient: true },
     });
 
-    if (
-      !appointment ||
-      resolveAppointmentParentId(appointment) !== params.parentId
-    ) {
+    if (!appointment) {
       throw new FormServiceError("Forbidden", 403);
     }
+    await assertParentCanViewAppointment(appointment, params.parentId);
   }
 
   // With an appointment the parent link is already proven above, so the
@@ -853,6 +852,40 @@ const resolveAppointmentParentId = (
 
   const parentId = (parent as { id?: unknown }).id;
   return typeof parentId === "string" ? parentId : undefined;
+};
+
+const resolveAppointmentPatientId = (
+  appointment: { patient?: unknown } | null | undefined,
+) => {
+  const patient = appointment?.patient;
+  if (!patient || typeof patient !== "object") return undefined;
+  const patientId = (patient as { id?: unknown }).id;
+  return typeof patientId === "string" ? patientId : undefined;
+};
+
+const assertParentCanViewAppointment = async (
+  appointment: { patient?: unknown },
+  parentId: string,
+) => {
+  const patientId = resolveAppointmentPatientId(appointment);
+  if (!patientId) throw new FormServiceError("Forbidden", 403);
+
+  const link = await prisma.parentPatient.findFirst({
+    where: {
+      parentId,
+      patientId,
+      status: "ACTIVE",
+      role: { in: ["PRIMARY", "CO_PARENT"] },
+    },
+    select: { role: true, permissions: true },
+  });
+
+  if (
+    !link ||
+    !hasCompanionFeature(link.role, link.permissions, "appointments")
+  ) {
+    throw new FormServiceError("Forbidden", 403);
+  }
 };
 
 // Helpers
@@ -1694,13 +1727,7 @@ export const FormService = {
     }
 
     if (params.viewerParentId) {
-      const appointmentParentId = resolveAppointmentParentId(appointment);
-      if (
-        !appointmentParentId ||
-        appointmentParentId !== params.viewerParentId
-      ) {
-        throw new FormServiceError("Forbidden", 403);
-      }
+      await assertParentCanViewAppointment(appointment, params.viewerParentId);
 
       try {
         await FormAssignmentService.markViewedForAppointment({

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -112,6 +112,9 @@ jest.mock("../../src/config/prisma", () => ({
       findFirst: jest.fn(),
       create: jest.fn(),
     },
+    parentPatient: {
+      findFirst: jest.fn(),
+    },
     patientCheckIn: {
       findFirst: jest.fn(),
       create: jest.fn(),
@@ -259,6 +262,10 @@ describe("AppointmentPrismaService", () => {
       type: "dog",
       speciesCode: "canislf",
     });
+    mockedPrisma.parentPatient.findFirst.mockResolvedValue({
+      role: "PRIMARY",
+      permissions: {},
+    } as any);
     mockedPrisma.roomUnitAssignment.findFirst.mockResolvedValue(null);
     mockedPrisma.roomUnitAssignment.update.mockResolvedValue({} as any);
     mockedPrisma.roomUnitAssignment.create.mockResolvedValue({
@@ -570,6 +577,47 @@ describe("AppointmentPrismaService", () => {
       });
       expect(mockedPrisma.appointment.findFirst).not.toHaveBeenCalled();
       expect(result.id).toBe("appt_1");
+    });
+
+    it("allows an active co-parent with appointment permission", async () => {
+      mockedPrisma.appointment.findUnique.mockResolvedValue(makeRow());
+      mockedPrisma.parentPatient.findFirst.mockResolvedValue({
+        role: "CO_PARENT",
+        permissions: { appointments: true },
+      } as any);
+      mockedPrisma.invoice.findMany.mockResolvedValue([]);
+
+      const result = await AppointmentPrismaService.getById("appt_1", {
+        parentId: "co_parent_1",
+      });
+
+      expect(result.id).toBe("appt_1");
+      expect(mockedPrisma.parentPatient.findFirst).toHaveBeenCalledWith({
+        where: {
+          parentId: "co_parent_1",
+          patientId: "comp_1",
+          status: "ACTIVE",
+          role: { in: ["PRIMARY", "CO_PARENT"] },
+        },
+        select: { role: true, permissions: true },
+      });
+    });
+
+    it("returns 404 when a co-parent appointment permission is revoked", async () => {
+      mockedPrisma.appointment.findUnique.mockResolvedValue(makeRow());
+      mockedPrisma.parentPatient.findFirst.mockResolvedValue({
+        role: "CO_PARENT",
+        permissions: { appointments: false },
+      } as any);
+
+      await expect(
+        AppointmentPrismaService.getById("appt_1", {
+          parentId: "co_parent_1",
+        }),
+      ).rejects.toMatchObject({
+        message: "Appointment not found",
+        statusCode: 404,
+      });
     });
 
     it("binds to organisationId via findFirst when org is supplied", async () => {
@@ -4229,10 +4277,11 @@ describe("AppointmentPrismaService", () => {
       });
     });
 
-    it("getById parent-scope: 404 when the row patient has no parent", async () => {
+    it("getById parent-scope: 404 without an active companion link", async () => {
       mockedPrisma.appointment.findFirst.mockResolvedValue(
         makeRow({ organisationId: "org_1", patient: { id: "comp_1" } }),
       );
+      mockedPrisma.parentPatient.findFirst.mockResolvedValue(null);
 
       await expect(
         AppointmentPrismaService.getById("appt_1", {

--- a/apps/backend/test/services/form.service.test.ts
+++ b/apps/backend/test/services/form.service.test.ts
@@ -94,6 +94,9 @@ jest.mock("src/config/prisma", () => ({
     formAssignment: {
       findFirst: jest.fn(),
     },
+    parentPatient: {
+      findFirst: jest.fn(),
+    },
     organization: {
       findUnique: jest.fn(),
     },
@@ -159,6 +162,7 @@ describe("FormService", () => {
     (prisma.appointment.updateMany as jest.Mock).mockReset();
     (prisma.appointment.findUnique as jest.Mock).mockReset();
     (prisma.appointment.findMany as jest.Mock).mockReset();
+    (prisma.parentPatient.findFirst as jest.Mock).mockReset();
 
     (prisma.organization.findUnique as jest.Mock).mockReset();
     (prisma.user.findMany as jest.Mock).mockReset();
@@ -194,6 +198,12 @@ describe("FormService", () => {
     (prisma.templateInstance.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.appointment.findMany as jest.Mock).mockResolvedValue([]);
     (prisma.user.findMany as jest.Mock).mockResolvedValue([]);
+    (prisma.parentPatient.findFirst as jest.Mock).mockImplementation(
+      ({ where }: any) =>
+        where.parentId === "parent-a"
+          ? { role: "PRIMARY", permissions: {} }
+          : null,
+    );
     (FormAssignmentService.listForAppointment as jest.Mock).mockResolvedValue(
       [],
     );
@@ -815,7 +825,11 @@ describe("FormService", () => {
       it("rejects a template that was never assigned", async () => {
         arrangeTemplate();
         (prisma.appointment.findFirst as jest.Mock).mockResolvedValue({
-          patient: { parent: { id: "parent-1" } },
+          patient: { id: "companion-1", parent: { id: "parent-1" } },
+        });
+        (prisma.parentPatient.findFirst as jest.Mock).mockResolvedValue({
+          role: "PRIMARY",
+          permissions: {},
         });
         (prisma.formAssignment.findFirst as jest.Mock).mockResolvedValue(null);
 
@@ -842,7 +856,11 @@ describe("FormService", () => {
       it("allows an assigned parent to submit their own appointment's form", async () => {
         arrangeTemplate();
         (prisma.appointment.findFirst as jest.Mock).mockResolvedValue({
-          patient: { parent: { id: "parent-1" } },
+          patient: { id: "companion-1", parent: { id: "parent-1" } },
+        });
+        (prisma.parentPatient.findFirst as jest.Mock).mockResolvedValue({
+          role: "PRIMARY",
+          permissions: {},
         });
         (prisma.formAssignment.findFirst as jest.Mock).mockResolvedValue({
           id: "assignment-1",
@@ -1332,13 +1350,52 @@ describe("FormService", () => {
     it("throws forbidden when viewer parent does not own appointment", async () => {
       (prisma.appointment.findUnique as jest.Mock).mockResolvedValue({
         organisationId: "o",
-        patient: { parent: { id: "parent-a" } },
+        patient: { id: "companion-a", parent: { id: "parent-a" } },
       });
 
       await expect(
         FormService.getFormsForAppointment({
           appointmentId: validId,
           viewerParentId: "parent-b",
+        }),
+      ).rejects.toThrow("Forbidden");
+    });
+
+    it("allows assigned paperwork for an authorised co-parent", async () => {
+      (prisma.appointment.findUnique as jest.Mock).mockResolvedValue({
+        organisationId: "o",
+        patient: { id: "companion-a", parent: { id: "parent-a" } },
+      });
+      (prisma.parentPatient.findFirst as jest.Mock).mockResolvedValue({
+        role: "CO_PARENT",
+        permissions: { appointments: true },
+      });
+      (prisma.organization.findUnique as jest.Mock).mockResolvedValue({
+        type: "HOSPITAL",
+      });
+
+      await expect(
+        FormService.getFormsForAppointment({
+          appointmentId: validId,
+          viewerParentId: "co-parent-a",
+        }),
+      ).resolves.toMatchObject({ appointmentId: validId });
+    });
+
+    it("rejects assigned paperwork after co-parent access is revoked", async () => {
+      (prisma.appointment.findUnique as jest.Mock).mockResolvedValue({
+        organisationId: "o",
+        patient: { id: "companion-a", parent: { id: "parent-a" } },
+      });
+      (prisma.parentPatient.findFirst as jest.Mock).mockResolvedValue({
+        role: "CO_PARENT",
+        permissions: { appointments: false },
+      });
+
+      await expect(
+        FormService.getFormsForAppointment({
+          appointmentId: validId,
+          viewerParentId: "co-parent-a",
         }),
       ).rejects.toThrow("Forbidden");
     });
@@ -1365,7 +1422,7 @@ describe("FormService", () => {
     it("marks assignments viewed when a parent opens the appointment forms", async () => {
       (prisma.appointment.findUnique as jest.Mock).mockResolvedValue({
         organisationId: "org-viewed",
-        patient: { parent: { id: "parent-a" } },
+        patient: { id: "companion-a", parent: { id: "parent-a" } },
       });
       (prisma.organization.findUnique as jest.Mock).mockResolvedValue({
         type: "HOSPITAL",

--- a/apps/mobileAppYC/__tests__/features/appointments/appointmentsSlice.test.ts
+++ b/apps/mobileAppYC/__tests__/features/appointments/appointmentsSlice.test.ts
@@ -354,13 +354,15 @@ describe('appointmentsSlice', () => {
         new Error('Load failed'),
       );
 
-      const store = createTestStore();
+      const store = createTestStore({items: [mockAppointment]});
       const result = await store.dispatch(
         fetchAppointmentById({appointmentId: 'appt-1'}),
       );
 
       expect(result.type).toBe('appointments/fetchById/rejected');
       expect(result.payload).toBe('Load failed');
+      expect((store.getState() as any).appointments.items).toEqual([]);
+      expect((store.getState() as any).appointments.error).toBe('Load failed');
     });
 
     it('rejects with fallback message for non-Error', async () => {

--- a/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
+++ b/apps/mobileAppYC/__tests__/features/appointments/screens/ViewAppointmentScreen.test.tsx
@@ -399,7 +399,14 @@ describe('ViewAppointmentScreen', () => {
           photo: 'http://biz.jpg',
         },
       ],
-      services: [{id: 'srv-1', name: 'Checkup', specialty: 'Vet'}],
+      services: [
+        {
+          id: 'srv-1',
+          name: 'Checkup',
+          specialty: 'Vet',
+          description: 'Bring the current medication packaging.',
+        },
+      ],
       employees: [{id: 'emp-1', name: 'Dr. Smith'}],
     },
     companion: {
@@ -915,6 +922,9 @@ describe('ViewAppointmentScreen', () => {
 
     it('renders full appointment details', () => {
       renderScreen();
+      expect(AppointmentSlice.fetchAppointmentById).toHaveBeenCalledWith({
+        appointmentId: mockAptId,
+      });
       expect(screen.getAllByText('Appointment Details')).toHaveLength(2);
       expect(screen.getAllByText('Test Vet').length).toBeGreaterThan(0);
       expect(screen.getByText('Checkup')).toBeTruthy();
@@ -922,6 +932,29 @@ describe('ViewAppointmentScreen', () => {
       expect(screen.getByText('Vaccine Record')).toBeTruthy();
       expect(screen.getByText('File1.pdf')).toBeTruthy();
       expect(screen.getByText('123 Test St')).toBeTruthy();
+      expect(screen.getByText('Before your visit')).toBeTruthy();
+      expect(
+        screen.getByText('Bring the current medication packaging.'),
+      ).toBeTruthy();
+      expect(screen.getByText('Instructions from Test Vet')).toBeTruthy();
+      expect(screen.getByText('Assigned paperwork')).toBeTruthy();
+      expect(
+        screen.getByText('No paperwork is assigned for this appointment.'),
+      ).toBeTruthy();
+    });
+
+    it('labels missing preparation instructions as unavailable', () => {
+      const state = clone(defaultState);
+      state.businesses.services[0].description = '   ';
+
+      renderScreen(state);
+
+      expect(
+        screen.getByText(
+          'Preparation instructions are unavailable. Contact the practice if you need guidance before this visit.',
+        ),
+      ).toBeTruthy();
+      expect(screen.queryByText('Instructions from Test Vet')).toBeNull();
     });
 
     it('shows a loading state and fetches when the appointment is missing', () => {

--- a/apps/mobileAppYC/src/features/appointments/appointmentsSlice.ts
+++ b/apps/mobileAppYC/src/features/appointments/appointmentsSlice.ts
@@ -487,6 +487,13 @@ const appointmentsSlice = createSlice({
       .addCase(fetchAppointmentById.fulfilled, (state, action) => {
         upsertAppointment(state, action.payload);
       })
+      .addCase(fetchAppointmentById.rejected, (state, action) => {
+        state.items = state.items.filter(
+          appointment => appointment.id !== action.meta.arg.appointmentId,
+        );
+        state.error =
+          (action.payload as string) ?? 'Unable to load appointment';
+      })
       .addCase(createAppointment.pending, state => {
         state.loading = true;
         state.error = null;

--- a/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
+++ b/apps/mobileAppYC/src/features/appointments/screens/ViewAppointmentScreen.tsx
@@ -365,22 +365,6 @@ const useAppointmentDisplayData = (params: {
   ]);
 };
 
-const useEnsureAppointmentLoaded = ({
-  apt,
-  appointmentId,
-  dispatch,
-}: {
-  apt: any;
-  appointmentId: string;
-  dispatch: AppDispatch;
-}) => {
-  useReactEffect(() => {
-    if (!apt) {
-      dispatch(fetchAppointmentById({appointmentId}));
-    }
-  }, [apt, appointmentId, dispatch]);
-};
-
 const useAppointmentDocumentsEffect = ({
   appointmentId,
   companionId,
@@ -769,7 +753,6 @@ export const ViewAppointmentScreen: React.FC = () => {
     lastDocumentsFetchTsRef.current = Date.now();
   }, []);
 
-  useEnsureAppointmentLoaded({apt, appointmentId, dispatch});
   useAppointmentDocumentsEffect({
     appointmentId,
     companionId: apt?.companionId,
@@ -810,6 +793,9 @@ export const ViewAppointmentScreen: React.FC = () => {
   }, [apt, appointmentId, dispatch]);
   useFocusEffect(
     React.useCallback(() => {
+      if (appointmentId) {
+        dispatch(fetchAppointmentById({appointmentId}));
+      }
       if (companionId) {
         dispatch(fetchExpensesForCompanion({companionId}));
       }
@@ -1203,6 +1189,7 @@ export const ViewAppointmentScreen: React.FC = () => {
   });
   const {dateTimeLabel} = formatAppointmentDateTime(apt);
   const merckOrganisationId = apt.businessId ?? null;
+  const preparationInstructions = service?.description?.trim() || null;
 
   const appointmentDetailItems: DetailItem[] = [
     {label: 'Date & Time', value: dateTimeLabel},
@@ -1258,6 +1245,23 @@ export const ViewAppointmentScreen: React.FC = () => {
               items={appointmentDetailItems}
             />
 
+            <View style={styles.detailsCard} accessibilityRole="summary">
+              <Text style={styles.sectionTitle}>
+                {i18next.t('appointments.visitPreparation.title')}
+              </Text>
+              <Text style={styles.emptyDocsText}>
+                {preparationInstructions ??
+                  i18next.t('appointments.visitPreparation.unavailable')}
+              </Text>
+              {preparationInstructions ? (
+                <Text style={styles.emptyDocsText}>
+                  {i18next.t('appointments.visitPreparation.source', {
+                    practice: businessName,
+                  })}
+                </Text>
+              ) : null}
+            </View>
+
             {apt.uploadedFiles?.length ? (
               <View style={styles.detailsCard}>
                 <Text style={styles.sectionTitle}>Your uploaded documents</Text>
@@ -1304,7 +1308,9 @@ export const ViewAppointmentScreen: React.FC = () => {
             </View>
 
             <View style={styles.detailsCard}>
-              <Text style={styles.sectionTitle}>Forms / prescription</Text>
+              <Text style={styles.sectionTitle}>
+                {i18next.t('appointments.visitPreparation.paperworkTitle')}
+              </Text>
               {(() => {
                 if (formsLoading) {
                   return <ActivityIndicator />;
@@ -1314,7 +1320,7 @@ export const ViewAppointmentScreen: React.FC = () => {
                 }
                 return (
                   <Text style={styles.emptyDocsText}>
-                    No forms for this appointment yet.
+                    {i18next.t('appointments.visitPreparation.noPaperwork')}
                   </Text>
                 );
               })()}

--- a/apps/mobileAppYC/src/localization/resources/en/common.json
+++ b/apps/mobileAppYC/src/localization/resources/en/common.json
@@ -371,7 +371,14 @@
     "chatLockedTitle": "Chat not open yet",
     "chatLockedBody": "Chat opens a day before your appointment.\n\nAppointment: {{appointmentTime}}\nOpens in: {{hours}}h {{minutes}}m",
     "chatUnavailableTitle": "Chat closed",
-    "chatUnavailableBody": "This appointment has ended and chat is no longer available."
+    "chatUnavailableBody": "This appointment has ended and chat is no longer available.",
+    "visitPreparation": {
+      "title": "Before your visit",
+      "source": "Instructions from {{practice}}",
+      "unavailable": "Preparation instructions are unavailable. Contact the practice if you need guidance before this visit.",
+      "paperworkTitle": "Assigned paperwork",
+      "noPaperwork": "No paperwork is assigned for this appointment."
+    }
   },
   "account": {
     "opensInBrowser": "Opens in your browser, outside the app",

--- a/apps/mobileAppYC/src/localization/resources/es/common.json
+++ b/apps/mobileAppYC/src/localization/resources/es/common.json
@@ -371,7 +371,14 @@
     "chatLockedTitle": "El chat aun no esta abierto",
     "chatLockedBody": "El chat se abre un dia antes de tu cita.\n\nCita: {{appointmentTime}}\nSe abre en: {{hours}} h {{minutes}} min",
     "chatUnavailableTitle": "Chat cerrado",
-    "chatUnavailableBody": "Esta cita ha terminado y el chat ya no esta disponible."
+    "chatUnavailableBody": "Esta cita ha terminado y el chat ya no esta disponible.",
+    "visitPreparation": {
+      "title": "Antes de la visita",
+      "source": "Instrucciones de {{practice}}",
+      "unavailable": "Las instrucciones de preparación no están disponibles. Contacta con la clínica si necesitas indicaciones antes de la visita.",
+      "paperworkTitle": "Documentación asignada",
+      "noPaperwork": "No hay documentación asignada para esta cita."
+    }
   },
   "account": {
     "opensInBrowser": "Se abre en tu navegador, fuera de la aplicacion",


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

The mobile appointment view does not present practice-authored preparation instructions, and appointment/form reads only recognize the primary owner embedded in the appointment payload.

## What is the new behavior?

- Presents service-authored preparation instructions and assigned paperwork in one localized, accessible appointment view.
- Authorizes active primary and co-parent links through the existing appointment permission model.
- Revalidates appointment access on screen focus and evicts stale cached appointment data after a rejected refresh.
- Covers the authorization, fallback, refresh, and cache-invalidation paths with mutation-checked Jest tests.

## Related Issue(s)

Fixes #3054

## Validation

- Backend: 499 suites / 11,825 tests passed; targeted touched-service coverage was 99.08% lines.
- Mobile: 508 suites / 8,712 tests passed; targeted touched-module coverage was 100% lines.
- Backend and mobile type-checks passed.
- Backend and mobile lints completed with no errors (the backend retains its existing warnings).
- Commit hooks passed gitleaks, secretlint, formatting, and staged mobile lint.

Manual simulator visual QA was not run; the screen behavior is covered by React Native Testing Library assertions.
