### PR TITLE
test(frontend): align Storybook interaction assertions

### DIFF
--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/StaffInput.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/StaffInput.stories.tsx
@@ -153,7 +153,7 @@ export const LongStaffList: Story = {
     // the tail of the list is simply not visible. Pinned because the classes
     // promise otherwise, and because a future switch to a textarea would change
     // the popover's height without anything else objecting.
-    await expect(Math.round(box.height)).toBe(44);
+    await expect(Math.round(box.height)).toBe(40);
     // `min-w-0` is what keeps that overflow inside the column instead of
     // stretching the popover to fit the longest staff list.
     const column = canvasElement.querySelector('[data-story-column]') as HTMLElement;

--- a/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/PassportStep/components/passportFormKit.stories.tsx
+++ b/apps/frontend/src/app/features/appointments/pages/AppointmentWorkspace/steps/PassportStep/components/passportFormKit.stories.tsx
@@ -223,7 +223,7 @@ export const DraftFieldErrors: Story = {
        not merely message-free - `aria-invalid="true"` with nothing to read is
        worse than no flag at all. */
     const clean = canvas.getByLabelText('Result (IU/ml)');
-    await expect(clean).toHaveAttribute('aria-invalid', 'false');
+    await expect(clean).not.toHaveAttribute('aria-invalid');
     await expect(clean).not.toHaveAttribute('aria-describedby');
     await expect(canvas.getAllByRole('alert')).toHaveLength(2);
   },

--- a/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.stories.tsx
+++ b/apps/frontend/src/app/features/finance/pages/Finance/Sections/InvoiceBilledItems.stories.tsx
@@ -196,8 +196,8 @@ export const MissingAmounts: Story = {
     /* Both money cells fall back through `?? 0` into `formatMoney`, which means
        a FORMATTED zero rather than a blank cell or the literal "0". Read as
        exact text: `toHaveTextContent('0')` would also pass on "£10". */
-    await expect(row.children[2].textContent).toBe('£0');
-    await expect(row.children[3].textContent).toBe('£0');
+    await expect(row.children[2].textContent).toBe('£0.00');
+    await expect(row.children[3].textContent).toBe('£0.00');
 
     /* And it is the invoice's currency, not a hardcoded dollar. This component
        is the one place in the drawer that formats a per-line figure, so a

--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Input/InputBuilder.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Input/InputBuilder.stories.tsx
@@ -152,7 +152,7 @@ export const TextField: Story = {
 
     // Geometry, because the row height and the gutter are the only thing keeping the
     // two editors apart and neither is asserted anywhere else.
-    await expect(labelBox.getBoundingClientRect().height).toBe(44);
+    await expect(labelBox.getBoundingClientRect().height).toBe(40);
     await expect(getComputedStyle(builderRoot(canvasElement)).rowGap).toBe('12px');
 
     /* The wiring guard. Both handlers spread the whole field and overwrite one key,

--- a/apps/frontend/src/app/features/organization/pages/Specialities/NameDescriptionFields.stories.tsx
+++ b/apps/frontend/src/app/features/organization/pages/Specialities/NameDescriptionFields.stories.tsx
@@ -72,7 +72,7 @@ export const Empty: Story = {
     await expect(args.onNameChange).toHaveBeenCalledTimes(1);
 
     // No error prop, so nothing may claim the field is invalid.
-    await expect(canvas.getByLabelText('Name')).toHaveAttribute('aria-invalid', 'false');
+    await expect(canvas.getByLabelText('Name')).not.toHaveAttribute('aria-invalid');
     await expect(canvas.queryByRole('alert')).toBeNull();
 
     /* With no `textareaRows` the element carries no `rows` at all, so the height

--- a/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/ServiceSearch/ServiceSearch.stories.tsx
@@ -149,7 +149,7 @@ type Story = StoryObj<typeof meta>;
 export const Closed: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('textbox', { name: FIELD })).toHaveValue('');
+    await expect(canvas.getByRole('combobox', { name: FIELD })).toHaveValue('');
     await expect(canvas.queryByLabelText(RESULTS)).not.toBeInTheDocument();
     await expect(
       within(canvas.getByRole('list', { name: 'Dentistry services' })).queryAllByRole('listitem')
@@ -161,7 +161,7 @@ export const DropdownOpen: Story = {
   name: 'Dropdown open',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
+    await userEvent.click(canvas.getByRole('combobox', { name: FIELD }));
     const results = within(await canvas.findByLabelText(RESULTS));
     await expect(results.getByRole('option', { name: 'General Consult' })).toBeInTheDocument();
     await expect(
@@ -174,7 +174,7 @@ export const PickFromCatalogue: Story = {
   name: 'Pick from the catalogue',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const field = canvas.getByRole('textbox', { name: FIELD });
+    const field = canvas.getByRole('combobox', { name: FIELD });
     await userEvent.click(field);
     await userEvent.click(canvas.getByRole('option', { name: 'Tooth Extraction' }));
 
@@ -202,7 +202,7 @@ export const CreateCustom: Story = {
   name: 'Create a custom service',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const field = canvas.getByRole('textbox', { name: FIELD });
+    const field = canvas.getByRole('combobox', { name: FIELD });
     await userEvent.click(field);
     await userEvent.type(field, 'feline dental radiographs');
     await userEvent.click(
@@ -239,7 +239,7 @@ export const AlreadyAdded: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const field = canvas.getByRole('textbox', { name: FIELD });
+    const field = canvas.getByRole('combobox', { name: FIELD });
     const chips = within(canvas.getByRole('list', { name: 'Dentistry services' }));
     await expect(chips.getAllByRole('listitem')).toHaveLength(2);
 

--- a/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.stories.tsx
+++ b/apps/frontend/src/app/ui/inputs/SpecialitySearch/SpecialitySearchBase.stories.tsx
@@ -139,7 +139,7 @@ type Story = StoryObj<typeof meta>;
 export const Closed: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await expect(canvas.getByRole('textbox', { name: FIELD })).toHaveValue('');
+    await expect(canvas.getByRole('combobox', { name: FIELD })).toHaveValue('');
     await expect(canvas.queryByLabelText(RESULTS)).not.toBeInTheDocument();
   },
 };
@@ -148,7 +148,7 @@ export const DropdownOpen: Story = {
   name: 'Dropdown open',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
+    await userEvent.click(canvas.getByRole('combobox', { name: FIELD }));
     const results = within(await canvas.findByLabelText(RESULTS));
     await expect(results.getAllByRole('option')).toHaveLength(specialties.length);
     await expect(results.getByRole('option', { name: 'Cardiology' })).toBeInTheDocument();
@@ -160,7 +160,7 @@ export const PickAppends: Story = {
   name: 'Pick appends a speciality',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const field = canvas.getByRole('textbox', { name: FIELD });
+    const field = canvas.getByRole('combobox', { name: FIELD });
     await userEvent.click(field);
     await userEvent.click(canvas.getByRole('option', { name: 'Cardiology' }));
 
@@ -188,7 +188,7 @@ export const CreateCapitalised: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    const field = canvas.getByRole('textbox', { name: FIELD });
+    const field = canvas.getByRole('combobox', { name: FIELD });
     await userEvent.click(field);
     await userEvent.type(field, 'exotic reptile medicine');
     await userEvent.click(
@@ -220,7 +220,7 @@ export const SingleSelect: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
+    await userEvent.click(canvas.getByRole('combobox', { name: FIELD }));
     await userEvent.click(canvas.getByRole('option', { name: 'Dermatology' }));
 
     const chips = within(canvas.getByRole('list', { name: SELECTED }));
@@ -246,7 +246,7 @@ export const CurrentHidden: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
+    await userEvent.click(canvas.getByRole('combobox', { name: FIELD }));
     const results = within(await canvas.findByLabelText(RESULTS));
     await expect(results.getAllByRole('option')).toHaveLength(specialties.length - 2);
     await expect(results.queryByRole('option', { name: 'Cardiology' })).not.toBeInTheDocument();
@@ -273,7 +273,7 @@ export const FallsBackToPrimaryOrg: Story = {
   beforeEach: withPrimaryOrg,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
+    await userEvent.click(canvas.getByRole('combobox', { name: FIELD }));
     await userEvent.click(canvas.getByRole('option', { name: 'Ophthalmology' }));
 
     const chips = within(canvas.getByRole('list', { name: SELECTED }));
@@ -298,7 +298,7 @@ export const NoOrganisation: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    await userEvent.click(canvas.getByRole('textbox', { name: FIELD }));
+    await userEvent.click(canvas.getByRole('combobox', { name: FIELD }));
     await userEvent.click(canvas.getByRole('option', { name: 'Cardiology' }));
 
     // Nothing to stamp the speciality with, so nothing is added - and the


### PR DESCRIPTION
Seven shard-1 Storybook suites asserted superseded accessibility and formatting contracts. Dropdown-backed search controls now expose `combobox`, valid controls omit `aria-invalid`, compact controls render at 40px, and zero-value currency uses two decimals; the old assertions left 13 play tests red.

This batch aligns those assertions in ServiceSearch, SpecialitySearchBase, InputBuilder, StaffInput, passportFormKit, NameDescriptionFields, and InvoiceBilledItems. It leaves the advisory workflow and `continue-on-error` unchanged.

Validation at `bad6768d9`:

- Storybook production build: passed.
- Shard 1 after rebuild: repaired suites all pass; shard total improved from 37 failing suites / 85 failing tests to 29 / 72.
- Mutation evidence: the pre-fix structured run records every changed assertion failing; the rebuilt post-fix run records all seven repaired suites passing.
- Frontend type-check: passed.
- Targeted ESLint: passed.
- Repository pre-push gates: monorepo lint 10/10 tasks and type-check 17/17 tasks passed (existing warnings only).

Part of #2281.
