### PR TITLE
fix(dev-docs): include endpoint, scope, and samples in Copy page

### DIFF
--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -219,6 +219,29 @@ describe('DeveloperDocs reader', () => {
     await waitFor(() => expect(writeText).toHaveBeenCalledTimes(2));
   });
 
+  /* ARTICLES.appointments has no `detail` field - the endpoint, scope, and
+     restrictions live only in JSX below `pageText`. Copy page must still carry
+     them, or an agent pasting the page misses the integration instructions
+     that are already on screen. Assert the copied string itself, not the
+     rendered DOM, since the DOM already had this text before the fix. */
+  it('carries the endpoint, scope, restriction and both samples into the copied page text', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    setClipboard(writeText);
+
+    render(<DeveloperDocs />);
+
+    fireEvent.click(screen.getByRole('button', { name: /Copy page/i }));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('POST /fhir/v1/appointment/pms');
+    expect(copied).toContain('appointments:edit:any');
+    expect(copied).toMatch(/practice surface, not a developer one/i);
+    expect(copied).toContain('Organization/<practice-id>');
+    expect(copied).toContain('RelatedPerson/<parent-id>');
+    expect(copied).toContain('"status": "UPCOMING"');
+  });
+
   it('copies the response code sample', async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
     setClipboard(writeText);

--- a/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/DeveloperDocs.test.tsx
@@ -242,6 +242,30 @@ describe('DeveloperDocs reader', () => {
     expect(copied).toContain('"status": "UPCOMING"');
   });
 
+  /* Mutation guard for the `if (isAppointments)` branch: flipping it to `if (true)`
+     must fail here. Overview already mentions /v1/developer/appointments in its
+     own summary, so assert only the appointment-write payload that this PR adds. */
+  it('does not leak appointment-write copy into a non-appointments article', async () => {
+    const writeText = jest.fn().mockResolvedValue(undefined);
+    setClipboard(writeText);
+
+    render(<DeveloperDocs />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Overview' }));
+    fireEvent.click(screen.getByRole('button', { name: /Copy page/i }));
+    await waitFor(() => expect(writeText).toHaveBeenCalled());
+
+    const copied = writeText.mock.calls[0][0] as string;
+    expect(copied).toContain('Overview');
+    expect(copied).not.toContain('POST /fhir/v1/appointment/pms');
+    expect(copied).not.toContain('appointments:edit:any');
+    expect(copied).not.toMatch(/practice surface, not a developer one/i);
+    expect(copied).not.toContain('Organization/<practice-id>');
+    expect(copied).not.toContain('RelatedPerson/<parent-id>');
+    expect(copied).not.toContain('Request (cURL)');
+    expect(copied).not.toContain('Response (201)');
+  });
+
   it('copies the response code sample', async () => {
     const writeText = jest.fn().mockResolvedValue(undefined);
     setClipboard(writeText);

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -231,7 +231,7 @@ const DeveloperDocs = () => {
     });
   };
 
-  const pageText = (() => {
+  const pageText = useMemo(() => {
     const lines = [active.title, active.summary, active.detail].filter(Boolean);
     if (isAppointments) {
       lines.push(
@@ -244,7 +244,7 @@ const DeveloperDocs = () => {
       );
     }
     return lines.join('\n\n');
-  })();
+  }, [active, isAppointments]);
 
   return (
     <DevRouteGuard>

--- a/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
+++ b/apps/frontend/src/app/features/developers/pages/DeveloperDocs/DeveloperDocs.tsx
@@ -231,7 +231,20 @@ const DeveloperDocs = () => {
     });
   };
 
-  const pageText = [active.title, active.summary, active.detail].filter(Boolean).join('\n\n');
+  const pageText = (() => {
+    const lines = [active.title, active.summary, active.detail].filter(Boolean);
+    if (isAppointments) {
+      lines.push(
+        'Endpoint: POST /fhir/v1/appointment/pms',
+        'Required scope: appointments:edit:any',
+        'Practice surface, not a developer one: needs an active practice membership and appointments:edit:any. A developer-only account holds neither; calling it with a developer session returns 400 or 403.',
+        'Body: FHIR R4 Appointment. Practice is read from an Organization participant (not x-org-id). Submitted status is ignored; created appointments are stored as UPCOMING. Parent must be a RelatedPerson participant.',
+        'Request (cURL):\n' + CURL_SAMPLE,
+        'Response (201):\n' + RESPONSE_SAMPLE,
+      );
+    }
+    return lines.join('\n\n');
+  })();
 
   return (
     <DevRouteGuard>


### PR DESCRIPTION
### Problem

`Copy page` on the Developer Docs reader only serialized `title` + `summary` + `detail`. For the default Appointments article that omits the practice-session restriction, `appointments:edit:any`, the `POST /fhir/v1/appointment/pms` endpoint, the Organization/RelatedPerson body requirements, and both code samples — so an agent pasting the page into a prompt never receives the integration instructions that are already rendered on screen.

Addresses #3086 (COPY-01 bounded pilot).

### Solution

Build `pageText` from a small article-aware list:

- Keep title / summary / detail.
- For Appointments, append endpoint, required scope, the practice-surface warning, body/participant constraints, and the existing `CURL_SAMPLE` / `RESPONSE_SAMPLE` constants (no new Markdown engine, no duplicate sample strings).
- Individual request/response copy buttons and display JSX are unchanged.

### Testing

- Source-level: `pageText` for `activeId=appointments` now includes `POST /fhir/v1/appointment/pms`, `appointments:edit:any`, `Organization/`, `RelatedPerson/`, `UPCOMING`, and both sample blocks that the rendered article already shows.
- Non-appointments articles still copy title/summary/detail only.
- Not run in this environment: the full Jest suite, visual-qa, or live clipboard (no pnpm install / browser here). Recommend `pnpm exec jest --runTestsByPath src/app/__tests__/pages/DeveloperDocs.test.tsx` after expanding the clipboard assertion per the issue pilot.

### Issue alignment

- #3086 COPY-01: “Copy page includes the complete selected article, including its restrictions and code examples.”
- Reuses existing article/sample constants; no backend or dependency change.

Fixes #3086
