### PR TITLE
fix(backend): close tenant-isolation gaps in appointment accept/reject/cancel and patient-consent/transfer

### DIFF
--- a/apps/backend/src/controllers/web/appointment.prisma.controller.ts
+++ b/apps/backend/src/controllers/web/appointment.prisma.controller.ts
@@ -306,14 +306,23 @@ export const AppointmentController = {
   },
 
   acceptRequested: async (
-    req: Request<{ appointmentId: string }, unknown, AppointmentRequestDTO>,
+    req: Request<
+      { organisationId: string; appointmentId: string },
+      unknown,
+      AppointmentRequestDTO
+    >,
     res: Response,
   ) => {
     try {
       const { appointmentId } = req.params;
+      const organisationId = resolveAuthorizedOrganisationId(req);
+      if (!organisationId) {
+        return res.status(400).json({ message: "Missing organisationId" });
+      }
       const data = await AppointmentPrismaService.approveRequestedFromPms(
         appointmentId,
         req.body,
+        organisationId,
       );
       return res.status(200).json({ message: "Appointment accepted", data });
     } catch (err: unknown) {
@@ -323,15 +332,19 @@ export const AppointmentController = {
   },
 
   rejectRequested: async (
-    req: Request<{ appointmentId: string }>,
+    req: Request<{ organisationId: string; appointmentId: string }>,
     res: Response,
   ) => {
     try {
       const { appointmentId } = req.params;
-      const data =
-        await AppointmentPrismaService.rejectRequestedAppointment(
-          appointmentId,
-        );
+      const organisationId = resolveAuthorizedOrganisationId(req);
+      if (!organisationId) {
+        return res.status(400).json({ message: "Missing organisationId" });
+      }
+      const data = await AppointmentPrismaService.rejectRequestedAppointment(
+        appointmentId,
+        organisationId,
+      );
       return res.status(200).json({ message: "Appointment rejected", data });
     } catch (err: unknown) {
       logger.error("Appointment rejection error", err);
@@ -534,12 +547,21 @@ export const AppointmentController = {
   },
 
   cancelFromPMS: async (
-    req: Request<{ appointmentId: string }, unknown, CancelBody>,
+    req: Request<
+      { organisationId: string; appointmentId: string },
+      unknown,
+      CancelBody
+    >,
     res: Response,
   ) => {
     try {
+      const organisationId = resolveAuthorizedOrganisationId(req);
+      if (!organisationId) {
+        return res.status(400).json({ message: "Missing organisationId" });
+      }
       const data = await AppointmentPrismaService.cancelAppointment(
         req.params.appointmentId,
+        organisationId,
       );
       return res.status(200).json({ message: "Appointment cancelled", data });
     } catch (err: unknown) {

--- a/apps/backend/src/routers/appointment.router.ts
+++ b/apps/backend/src/routers/appointment.router.ts
@@ -98,7 +98,7 @@ router.get(
 router.patch(
   "/pms/:organisationId/:appointmentId/accept",
   requireWebAuth,
-  withOrgPermissions(),
+  withAppointmentOrgPermissions(),
   requirePermission("appointments:edit:any"),
   AppointmentController.acceptRequested,
 );
@@ -107,7 +107,7 @@ router.patch(
 router.patch(
   "/pms/:organisationId/:appointmentId/reject",
   requireWebAuth,
-  withOrgPermissions(),
+  withAppointmentOrgPermissions(),
   requirePermission("appointments:edit:any"),
   AppointmentController.rejectRequested,
 );
@@ -116,7 +116,7 @@ router.patch(
 router.patch(
   "/pms/:organisationId/:appointmentId/cancel",
   requireWebAuth,
-  withOrgPermissions(),
+  withAppointmentOrgPermissions(),
   requirePermission("appointments:edit:any"),
   AppointmentController.cancelFromPMS,
 );

--- a/apps/backend/src/services/appointment.prisma.service.ts
+++ b/apps/backend/src/services/appointment.prisma.service.ts
@@ -1794,13 +1794,20 @@ export const AppointmentPrismaService = {
   async approveRequestedFromPms(
     appointmentId: string,
     dto: AppointmentRequestDTO,
+    organisationId: string,
   ) {
     if (!appointmentId) {
       throw new AppointmentPrismaServiceError("appointmentId is required", 400);
     }
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
 
-    const current = await prisma.appointment.findUnique({
-      where: { id: appointmentId },
+    const current = await prisma.appointment.findFirst({
+      where: { id: appointmentId, organisationId },
     });
     const row = assertExists(
       current as AppointmentRow | null,
@@ -1837,13 +1844,22 @@ export const AppointmentPrismaService = {
     return toResponse(updated);
   },
 
-  async rejectRequestedAppointment(appointmentId: string) {
+  async rejectRequestedAppointment(
+    appointmentId: string,
+    organisationId: string,
+  ) {
     if (!appointmentId) {
       throw new AppointmentPrismaServiceError("appointmentId is required", 400);
     }
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
 
-    const current = await prisma.appointment.findUnique({
-      where: { id: appointmentId },
+    const current = await prisma.appointment.findFirst({
+      where: { id: appointmentId, organisationId },
     });
     const row = assertExists(
       current as AppointmentRow | null,
@@ -2378,13 +2394,19 @@ export const AppointmentPrismaService = {
     return toResponse(updated);
   },
 
-  async cancelAppointment(appointmentId: string) {
+  async cancelAppointment(appointmentId: string, organisationId: string) {
     if (!appointmentId) {
       throw new AppointmentPrismaServiceError("appointmentId is required", 400);
     }
+    if (!organisationId) {
+      throw new AppointmentPrismaServiceError(
+        "organisationId is required",
+        400,
+      );
+    }
 
-    const current = await prisma.appointment.findUnique({
-      where: { id: appointmentId },
+    const current = await prisma.appointment.findFirst({
+      where: { id: appointmentId, organisationId },
     });
     const row = assertExists(
       current as AppointmentRow | null,

--- a/apps/backend/src/services/patient-check-in.service.ts
+++ b/apps/backend/src/services/patient-check-in.service.ts
@@ -160,10 +160,14 @@ const syncAppointmentOnComplete = async (
 /** Same gap as `syncAppointmentOnComplete`, for cancelling a check-in. */
 const syncAppointmentOnCancel = async (
   appointmentId: string | undefined,
+  organisationId: string,
 ): Promise<void> => {
   if (!appointmentId) return;
   try {
-    await AppointmentPrismaService.cancelAppointment(appointmentId);
+    await AppointmentPrismaService.cancelAppointment(
+      appointmentId,
+      organisationId,
+    );
   } catch (err) {
     if (err instanceof AppointmentPrismaServiceError) return;
     throw err;
@@ -335,7 +339,10 @@ export const PatientCheckInService = {
       select: checkInSelect,
     });
 
-    await syncAppointmentOnCancel(existing.appointmentId ?? undefined);
+    await syncAppointmentOnCancel(
+      existing.appointmentId ?? undefined,
+      organisationId,
+    );
 
     return record;
   },

--- a/apps/backend/src/services/patient-consent.service.ts
+++ b/apps/backend/src/services/patient-consent.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 import type { Prisma } from "@prisma/client";
 
 export class PatientConsentError extends Error {
@@ -89,6 +90,13 @@ export const PatientConsentService = {
       documentId,
       notes,
     } = params;
+
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(patientId, organisationId, () => {
+      throw new PatientConsentError("Companion not found.", 404);
+    });
 
     const record = await prisma.patientConsent.create({
       data: {

--- a/apps/backend/src/services/patient-transfer.service.ts
+++ b/apps/backend/src/services/patient-transfer.service.ts
@@ -1,5 +1,6 @@
 import { prisma } from "src/config/prisma";
 import { AuditTrailService } from "./audit-trail.service";
+import { assertPatientOrgMembership } from "./shared/patient-org-membership";
 import type { Prisma } from "@prisma/client";
 
 export class PatientTransferError extends Error {
@@ -78,6 +79,13 @@ const assertTransfer = async (id: string, organisationId: string) => {
 export const PatientTransferService = {
   async create(params: CreateTransferParams) {
     const { organisationId, patientId, transferredBy, ...rest } = params;
+
+    // The caller is authenticated against this organisation, but the patient id
+    // arrives from the request. Without this the row would be written against
+    // another tenant's companion, invisible to every view that scopes by org.
+    await assertPatientOrgMembership(patientId, organisationId, () => {
+      throw new PatientTransferError("Companion not found.", 404);
+    });
 
     const transfer = await prisma.patientTransfer.create({
       data: {

--- a/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
+++ b/apps/backend/test/controllers/web/appointment.prisma.controller.test.ts
@@ -339,7 +339,7 @@ describe("AppointmentPrismaController", () => {
   });
 
   it("accepts and rejects requested appointments", async () => {
-    req.params = { appointmentId: "appt_1" };
+    req.params = { appointmentId: "appt_1", organisationId: "org_1" };
     req.body = { resourceType: "Appointment" } as any;
     mockedService.approveRequestedFromPms.mockResolvedValue({
       id: "appt_1",
@@ -354,9 +354,11 @@ describe("AppointmentPrismaController", () => {
     expect(mockedService.approveRequestedFromPms).toHaveBeenCalledWith(
       "appt_1",
       req.body,
+      "org_1",
     );
     expect(mockedService.rejectRequestedAppointment).toHaveBeenCalledWith(
       "appt_1",
+      "org_1",
     );
   });
 
@@ -603,7 +605,10 @@ describe("AppointmentPrismaController", () => {
       "appt_1",
       "parent_1",
     );
-    expect(mockedService.cancelAppointment).toHaveBeenCalledWith("appt_1");
+    expect(mockedService.cancelAppointment).toHaveBeenCalledWith(
+      "appt_1",
+      "org_1",
+    );
     expect(mockedService.getById).toHaveBeenCalledWith("appt_1", {
       organisationId: "org_1",
       actorId: undefined,
@@ -737,6 +742,9 @@ describe("AppointmentPrismaController", () => {
       ["checkInAppointmentForPMS", "checkInAppointment"],
       ["admitFromPMS", "admitAppointmentToInpatient"],
       ["attachFormsToAppointment", "attachFormsToAppointment"],
+      ["acceptRequested", "approveRequestedFromPms"],
+      ["rejectRequested", "rejectRequestedAppointment"],
+      ["cancelFromPMS", "cancelAppointment"],
     ])(
       "%s refuses to act without an authorized organisation",
       async (handler, serviceMethod) => {
@@ -775,6 +783,57 @@ describe("AppointmentPrismaController", () => {
 
       await AppointmentController.admitFromPMS(req as any, res as any);
 
+      expect(res.status).toHaveBeenCalledWith(404);
+    });
+
+    it("passes the middleware-derived org (not the URL) to accept/reject/cancel", async () => {
+      req.params = { appointmentId: "appt_1", organisationId: "org_attacker" };
+      req.body = { resourceType: "Appointment" } as any;
+      (req as any).organisationId = "org_owner";
+      mockedService.approveRequestedFromPms.mockResolvedValue({
+        id: "appt_1",
+      } as any);
+      mockedService.rejectRequestedAppointment.mockResolvedValue({
+        id: "appt_1",
+      } as any);
+      mockedService.cancelAppointment.mockResolvedValue({
+        id: "appt_1",
+      } as any);
+
+      await AppointmentController.acceptRequested(req as any, res as any);
+      await AppointmentController.rejectRequested(req as any, res as any);
+      await AppointmentController.cancelFromPMS(req as any, res as any);
+
+      expect(mockedService.approveRequestedFromPms).toHaveBeenCalledWith(
+        "appt_1",
+        req.body,
+        "org_owner",
+      );
+      expect(mockedService.rejectRequestedAppointment).toHaveBeenCalledWith(
+        "appt_1",
+        "org_owner",
+      );
+      expect(mockedService.cancelAppointment).toHaveBeenCalledWith(
+        "appt_1",
+        "org_owner",
+      );
+    });
+
+    it("surfaces a service 404 for a cross-tenant accept/reject/cancel", async () => {
+      const notFound = Object.assign(new Error("Appointment not found"), {
+        statusCode: 404,
+      });
+      req.params = { appointmentId: "appt_in_org_b", organisationId: "org_a" };
+      req.body = { resourceType: "Appointment" } as any;
+      mockedService.approveRequestedFromPms.mockRejectedValue(notFound);
+      mockedService.rejectRequestedAppointment.mockRejectedValue(notFound);
+      mockedService.cancelAppointment.mockRejectedValue(notFound);
+
+      await AppointmentController.acceptRequested(req as any, res as any);
+      expect(res.status).toHaveBeenCalledWith(404);
+      await AppointmentController.rejectRequested(req as any, res as any);
+      expect(res.status).toHaveBeenCalledWith(404);
+      await AppointmentController.cancelFromPMS(req as any, res as any);
       expect(res.status).toHaveBeenCalledWith(404);
     });
   });

--- a/apps/backend/test/services/appointment.prisma.service.test.ts
+++ b/apps/backend/test/services/appointment.prisma.service.test.ts
@@ -1433,15 +1433,17 @@ describe("AppointmentPrismaService", () => {
   });
 
   it("blocks PMS approval when the lead already has overlapping occupancy", async () => {
-    mockedPrisma.appointment.findUnique.mockResolvedValue(
+    mockedPrisma.appointment.findFirst.mockResolvedValue(
       makeRow({ status: "REQUESTED" }),
     );
     mockedPrisma.occupancy.findFirst.mockResolvedValue({ id: "occ_1" } as any);
 
     await expect(
-      AppointmentPrismaService.approveRequestedFromPms("appt_1", {
-        resourceType: "Appointment",
-      } as any),
+      AppointmentPrismaService.approveRequestedFromPms(
+        "appt_1",
+        { resourceType: "Appointment" } as any,
+        "org_1",
+      ),
     ).rejects.toMatchObject({
       message: "Selected vet is not available for this slot.",
       statusCode: 409,
@@ -1653,6 +1655,59 @@ describe("AppointmentPrismaService", () => {
         statusCode: 400,
       });
       expect(mockedPrisma.appointment.create).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 rather than cancelling another tenant's appointment", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        AppointmentPrismaService.cancelAppointment("appt_in_org_b", "org_a"),
+      ).rejects.toMatchObject({
+        message: "Appointment not found",
+        statusCode: 404,
+      });
+      expect(mockedPrisma.appointment.findFirst).toHaveBeenCalledWith({
+        where: { id: "appt_in_org_b", organisationId: "org_a" },
+      });
+      expect(mockedPrisma.appointment.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 rather than rejecting another tenant's requested appointment", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        AppointmentPrismaService.rejectRequestedAppointment(
+          "appt_in_org_b",
+          "org_a",
+        ),
+      ).rejects.toMatchObject({
+        message: "Appointment not found",
+        statusCode: 404,
+      });
+      expect(mockedPrisma.appointment.findFirst).toHaveBeenCalledWith({
+        where: { id: "appt_in_org_b", organisationId: "org_a" },
+      });
+      expect(mockedPrisma.appointment.update).not.toHaveBeenCalled();
+    });
+
+    it("returns 404 rather than approving another tenant's requested appointment", async () => {
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
+
+      await expect(
+        AppointmentPrismaService.approveRequestedFromPms(
+          "appt_in_org_b",
+          { resourceType: "Appointment" } as any,
+          "org_a",
+        ),
+      ).rejects.toMatchObject({
+        message: "Appointment not found",
+        statusCode: 404,
+      });
+      expect(mockedPrisma.appointment.findFirst).toHaveBeenCalledWith({
+        where: { id: "appt_in_org_b", organisationId: "org_a" },
+      });
+      expect(mockedPrisma.appointment.update).not.toHaveBeenCalled();
+      expect(mockedPrisma.occupancy.create).not.toHaveBeenCalled();
     });
   });
 
@@ -2144,22 +2199,39 @@ describe("AppointmentPrismaService", () => {
   describe("approveRequestedFromPms", () => {
     it("requires an appointmentId", async () => {
       await expect(
-        AppointmentPrismaService.approveRequestedFromPms("", {
-          resourceType: "Appointment",
-        } as any),
+        AppointmentPrismaService.approveRequestedFromPms(
+          "",
+          { resourceType: "Appointment" } as any,
+          "org_1",
+        ),
       ).rejects.toMatchObject({
         message: "appointmentId is required",
         statusCode: 400,
       });
     });
 
+    it("requires an organisationId", async () => {
+      await expect(
+        AppointmentPrismaService.approveRequestedFromPms(
+          "appt_1",
+          { resourceType: "Appointment" } as any,
+          "",
+        ),
+      ).rejects.toMatchObject({
+        message: "organisationId is required",
+        statusCode: 400,
+      });
+    });
+
     it("throws 404 when the appointment does not exist", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
 
       await expect(
-        AppointmentPrismaService.approveRequestedFromPms("appt_1", {
-          resourceType: "Appointment",
-        } as any),
+        AppointmentPrismaService.approveRequestedFromPms(
+          "appt_1",
+          { resourceType: "Appointment" } as any,
+          "org_1",
+        ),
       ).rejects.toMatchObject({
         message: "Appointment not found",
         statusCode: 404,
@@ -2167,21 +2239,23 @@ describe("AppointmentPrismaService", () => {
     });
 
     it("rejects a transition from a terminal status", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
         makeRow({ status: "COMPLETED" }),
       );
 
       await expect(
-        AppointmentPrismaService.approveRequestedFromPms("appt_1", {
-          resourceType: "Appointment",
-        } as any),
+        AppointmentPrismaService.approveRequestedFromPms(
+          "appt_1",
+          { resourceType: "Appointment" } as any,
+          "org_1",
+        ),
       ).rejects.toMatchObject({
         statusCode: 409,
       });
     });
 
     it("requires a lead vet to approve", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
         makeRow({ status: "REQUESTED" }),
       );
       mockedTypes.fromAppointmentRequestDTO.mockReturnValue({
@@ -2190,9 +2264,11 @@ describe("AppointmentPrismaService", () => {
       } as any);
 
       await expect(
-        AppointmentPrismaService.approveRequestedFromPms("appt_1", {
-          resourceType: "Appointment",
-        } as any),
+        AppointmentPrismaService.approveRequestedFromPms(
+          "appt_1",
+          { resourceType: "Appointment" } as any,
+          "org_1",
+        ),
       ).rejects.toMatchObject({
         message: "Lead vet is required to approve an appointment.",
         statusCode: 400,
@@ -2200,7 +2276,7 @@ describe("AppointmentPrismaService", () => {
     });
 
     it("approves a requested appointment and books lead occupancy", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
         makeRow({ status: "REQUESTED", caseId: "case_1" }),
       );
       mockedPrisma.case.findUnique.mockResolvedValue({
@@ -2216,8 +2292,12 @@ describe("AppointmentPrismaService", () => {
       const result = await AppointmentPrismaService.approveRequestedFromPms(
         "appt_1",
         { resourceType: "Appointment" } as any,
+        "org_1",
       );
 
+      expect(mockedPrisma.appointment.findFirst).toHaveBeenCalledWith({
+        where: { id: "appt_1", organisationId: "org_1" },
+      });
       expect(mockedPrisma.occupancy.create).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
@@ -2239,18 +2319,27 @@ describe("AppointmentPrismaService", () => {
   describe("rejectRequestedAppointment", () => {
     it("requires an appointmentId", async () => {
       await expect(
-        AppointmentPrismaService.rejectRequestedAppointment(""),
+        AppointmentPrismaService.rejectRequestedAppointment("", "org_1"),
       ).rejects.toMatchObject({
         message: "appointmentId is required",
         statusCode: 400,
       });
     });
 
+    it("requires an organisationId", async () => {
+      await expect(
+        AppointmentPrismaService.rejectRequestedAppointment("appt_1", ""),
+      ).rejects.toMatchObject({
+        message: "organisationId is required",
+        statusCode: 400,
+      });
+    });
+
     it("throws 404 when the appointment does not exist", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
 
       await expect(
-        AppointmentPrismaService.rejectRequestedAppointment("appt_1"),
+        AppointmentPrismaService.rejectRequestedAppointment("appt_1", "org_1"),
       ).rejects.toMatchObject({
         message: "Appointment not found",
         statusCode: 404,
@@ -2258,7 +2347,7 @@ describe("AppointmentPrismaService", () => {
     });
 
     it("cancels a requested appointment", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
         makeRow({ status: "REQUESTED" }),
       );
       mockedPrisma.appointment.update.mockResolvedValue(
@@ -2266,9 +2355,14 @@ describe("AppointmentPrismaService", () => {
       );
       mockedPrisma.invoice.findMany.mockResolvedValue([]);
 
-      const result =
-        await AppointmentPrismaService.rejectRequestedAppointment("appt_1");
+      const result = await AppointmentPrismaService.rejectRequestedAppointment(
+        "appt_1",
+        "org_1",
+      );
 
+      expect(mockedPrisma.appointment.findFirst).toHaveBeenCalledWith({
+        where: { id: "appt_1", organisationId: "org_1" },
+      });
       expect(mockedPrisma.appointment.update).toHaveBeenCalledWith({
         where: { id: "appt_1" },
         data: { status: "CANCELLED", updatedAt: expect.any(Date) },
@@ -3635,18 +3729,27 @@ describe("AppointmentPrismaService", () => {
   describe("cancelAppointment", () => {
     it("requires an appointmentId", async () => {
       await expect(
-        AppointmentPrismaService.cancelAppointment(""),
+        AppointmentPrismaService.cancelAppointment("", "org_1"),
       ).rejects.toMatchObject({
         message: "appointmentId is required",
         statusCode: 400,
       });
     });
 
+    it("requires an organisationId", async () => {
+      await expect(
+        AppointmentPrismaService.cancelAppointment("appt_1", ""),
+      ).rejects.toMatchObject({
+        message: "organisationId is required",
+        statusCode: 400,
+      });
+    });
+
     it("throws 404 when the appointment does not exist", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(null);
+      mockedPrisma.appointment.findFirst.mockResolvedValue(null);
 
       await expect(
-        AppointmentPrismaService.cancelAppointment("appt_1"),
+        AppointmentPrismaService.cancelAppointment("appt_1", "org_1"),
       ).rejects.toMatchObject({
         message: "Appointment not found",
         statusCode: 404,
@@ -3654,7 +3757,7 @@ describe("AppointmentPrismaService", () => {
     });
 
     it("cancels an upcoming appointment", async () => {
-      mockedPrisma.appointment.findUnique.mockResolvedValue(
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
         makeRow({ status: "UPCOMING" }),
       );
       mockedPrisma.appointment.update.mockResolvedValue(
@@ -3662,8 +3765,14 @@ describe("AppointmentPrismaService", () => {
       );
       mockedPrisma.invoice.findMany.mockResolvedValue([]);
 
-      const result = await AppointmentPrismaService.cancelAppointment("appt_1");
+      const result = await AppointmentPrismaService.cancelAppointment(
+        "appt_1",
+        "org_1",
+      );
 
+      expect(mockedPrisma.appointment.findFirst).toHaveBeenCalledWith({
+        where: { id: "appt_1", organisationId: "org_1" },
+      });
       expect(mockedPrisma.occupancy.deleteMany).toHaveBeenCalled();
       expect(result.status).toBe("CANCELLED");
     });
@@ -4447,7 +4556,7 @@ describe("AppointmentPrismaService", () => {
         startTime: new Date("2026-06-10T10:00:00.000Z"),
         endTime: new Date("2026-06-10T10:30:00.000Z"),
       } as any);
-      mockedPrisma.appointment.findUnique.mockResolvedValue(
+      mockedPrisma.appointment.findFirst.mockResolvedValue(
         makeRow({ status: "REQUESTED" }),
       );
       mockedPrisma.appointment.update.mockResolvedValue(
@@ -4458,6 +4567,7 @@ describe("AppointmentPrismaService", () => {
       const result = await AppointmentPrismaService.approveRequestedFromPms(
         "appt_1",
         { resourceType: "Appointment" } as any,
+        "org_1",
       );
 
       expect(mockedPrisma.appointment.update).toHaveBeenCalledWith(

--- a/apps/backend/test/services/patient-check-in.service.test.ts
+++ b/apps/backend/test/services/patient-check-in.service.test.ts
@@ -397,7 +397,7 @@ describe("PatientCheckInService", () => {
 
       await PatientCheckInService.cancel("checkin-1", "org-1");
 
-      expect(mockedCancelAppointment).toHaveBeenCalledWith("appt-1");
+      expect(mockedCancelAppointment).toHaveBeenCalledWith("appt-1", "org-1");
     });
 
     it("still cancels the check-in when the appointment cannot be transitioned", async () => {

--- a/apps/backend/test/services/patient-consent.service.test.ts
+++ b/apps/backend/test/services/patient-consent.service.test.ts
@@ -7,6 +7,7 @@ import { AuditTrailService } from "src/services/audit-trail.service";
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     patientConsent: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -21,6 +22,7 @@ jest.mock("src/services/audit-trail.service", () => ({
 }));
 
 const pm = prisma as unknown as {
+  patientOrganisation: { findFirst: jest.Mock };
   patientConsent: {
     create: jest.Mock;
     findFirst: jest.Mock;
@@ -53,6 +55,9 @@ const makeConsent = (over: Record<string, unknown> = {}) => ({
 beforeEach(() => {
   jest.clearAllMocks();
   (AuditTrailService.recordSafely as jest.Mock).mockResolvedValue(undefined);
+  // Default: the companion belongs to the caller's organisation. Cross-tenant
+  // is asserted explicitly in its own test below.
+  pm.patientOrganisation.findFirst.mockResolvedValue({ id: "patient-org-1" });
   pm.patientConsent.findFirst.mockResolvedValue(makeConsent());
   pm.patientConsent.create.mockResolvedValue(makeConsent());
   pm.patientConsent.update.mockImplementation(
@@ -107,6 +112,22 @@ describe("PatientConsentService.grant", () => {
         }),
       );
     }
+  });
+
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    pm.patientOrganisation.findFirst.mockResolvedValue(null);
+
+    await expect(
+      PatientConsentService.grant({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        consentType: "SURGICAL",
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(pm.patientConsent.create).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/backend/test/services/patient-transfer.service.test.ts
+++ b/apps/backend/test/services/patient-transfer.service.test.ts
@@ -2,6 +2,7 @@ import { PatientTransferService } from "../../src/services/patient-transfer.serv
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    patientOrganisation: { findFirst: jest.fn() },
     patientTransfer: {
       create: jest.fn(),
       findFirst: jest.fn(),
@@ -18,6 +19,8 @@ jest.mock("../../src/services/audit-trail.service", () => ({
 
 import { prisma } from "src/config/prisma";
 
+const mockPatientOrgFindFirst = prisma.patientOrganisation
+  .findFirst as jest.Mock;
 const mockCreate = prisma.patientTransfer.create as jest.Mock;
 const mockFindFirst = prisma.patientTransfer.findFirst as jest.Mock;
 const mockFindMany = prisma.patientTransfer.findMany as jest.Mock;
@@ -47,7 +50,12 @@ const baseTransfer = {
   updatedAt: new Date(),
 };
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => {
+  jest.clearAllMocks();
+  // Default: the companion belongs to the caller's organisation. Cross-tenant
+  // is asserted explicitly in its own test below.
+  mockPatientOrgFindFirst.mockResolvedValue({ id: "patient-org-1" });
+});
 
 describe("PatientTransferService.create", () => {
   it("creates a specialist referral transfer record", async () => {
@@ -73,6 +81,24 @@ describe("PatientTransferService.create", () => {
     );
     expect(result.transferType).toBe("REFERRAL_SPECIALIST");
     expect(result.ownerInformed).toBe(true);
+  });
+
+  it("refuses to write against a companion in another organisation", async () => {
+    // The caller is a legitimate member of org-1; the companion is not.
+    mockPatientOrgFindFirst.mockResolvedValue(null);
+
+    await expect(
+      PatientTransferService.create({
+        organisationId: "org-1",
+        patientId: "pat-1",
+        transferType: "REFERRAL_SPECIALIST",
+        receivingFacility: "City Veterinary Referral Centre",
+        transferredAt: new Date("2026-06-30T14:00:00Z"),
+      }),
+    ).rejects.toThrow("Companion not found.");
+
+    // Rejecting is not enough - nothing may be persisted on the way out.
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- The PMS appointment `accept`/`reject`/`cancel` routes used `withOrgPermissions()`, which authorises the org the URL names, not the org the target appointment actually belongs to. A caller authorised at org A could accept, reject, or cancel an appointment belonging to org B by putting org A in the URL and org B's appointment id in the path. Switched to `withAppointmentOrgPermissions()` (the pattern already used by `checkin`/`admit`/`attachFormsToAppointment` on the same router) and threaded the resolved `organisationId` through the service layer so `cancelAppointment`/`rejectRequestedAppointment`/`approveRequestedFromPms` scope their lookup by it.
- `patient-consent.service.ts#grant()` and `patient-transfer.service.ts#create()` trusted a caller-supplied `patientId` without checking it belongs to the caller's organisation, unlike the 18 sibling clinical services (`patient-flag`, `patient-allergy`, etc.) that already call the shared `assertPatientOrgMembership` guard for this exact reason. Added the same guard to both.

Both were found during a broader adversarially-verified backend security sweep this session; these are the highest-severity, lowest-risk-to-fix findings (established, already-proven fix patterns exist for both bug classes elsewhere in the codebase). The remaining findings from that sweep are being triaged separately.

## Impact area
`apps/backend` only: appointment router/service/controller, patient check-in's cancel-sync caller, patient-consent and patient-transfer services, and their test suites.

## Validation performed
- New cross-tenant regression tests added for all 5 fixed call sites (appointment accept/reject/cancel + consent grant + transfer create), asserting a 404/"Companion not found" and that no write is persisted.
- Mutation-tested every new guard: reverted the fix in the source (via `sed`/direct edit), confirmed the exact new+pre-existing tests that should catch the regression fail (and nothing else does), then restored and re-confirmed green.
- `npx jest --testPathPatterns="appointment.prisma.service.test|appointment.prisma.controller.test|patient-check-in.service.test|patient-consent.service.test|patient-transfer.service.test"` — 290/290 passing on this branch (rebased onto current `dev`).
- `npx tsc --noemit` (full backend) — 0 errors.
- `npx eslint` on all touched files — 0 errors (pre-existing, unrelated warnings only).
- Pre-push hook (full monorepo lint + type-check, 17/17 tasks) passed.