### PR TITLE
fix(frontend): brighten compliance badge marks for legibility in dark theme

### DIFF
--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.css
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.css
@@ -205,6 +205,21 @@
   height: 56px;
 }
 
+/* The GDPR/ISO/FHIR marks are solid dark ink on a transparent background, and
+   the SOC 2 seal is a near-black AICPA-issued circle - both read fine on the
+   light footer but disappear into it once html[data-theme='dark'] turns the
+   footer's own background dark. These are official third-party marks (AICPA's
+   licensed SOC seal among them), so the fix is the same brightness/grayscale
+   filter AuthShell.tsx already uses for the identical problem on its
+   permanently-dark brand panel - it recolours the existing pixels for
+   legibility without redrawing or replacing any mark. */
+html[data-theme='dark'] .gdpr-footer,
+html[data-theme='dark'] .soc-footer,
+html[data-theme='dark'] .iso-footer,
+html[data-theme='dark'] .fhir-footer {
+  filter: grayscale(1) brightness(2.2);
+}
+
 @media screen and (max-width: 1024px) {
   .Footersec {
     padding: 0px 25px 25px 25px;

--- a/apps/frontend/src/app/ui/widgets/Footer/Footer.stories.tsx
+++ b/apps/frontend/src/app/ui/widgets/Footer/Footer.stories.tsx
@@ -1,5 +1,6 @@
 import { PLATFORM_STATUS_API_URL } from '@/app/hooks/usePlatformStatus';
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect, within } from 'storybook/test';
 
 import Footer from './Footer';
 
@@ -122,6 +123,48 @@ export const Mobile: Story = {
           'Below the tablet breakpoint the link columns stack under the brand block and the legal ' +
           'copy centres. The badge strip is the part that struggles here - five fixed-width logos on ' +
           'a 375px canvas.',
+      },
+    },
+  },
+};
+
+export const DarkTheme: Story = {
+  name: 'Compliance badges (dark)',
+  globals: { theme: 'dark' },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(document.documentElement.dataset.theme).toBe('dark');
+
+    /* GDPR/ISO/FHIR are solid dark ink on a transparent PNG and the SOC 2 seal
+       is AICPA's own near-black circle - all four disappear into the footer's
+       own dark background without this filter. Asserting the computed style
+       (not just that the <img> is present) is the point: a broken selector
+       still renders four healthy-looking, invisible images. */
+    const badges = [
+      canvas.getAllByRole('img').find((img) => img.className.includes('gdpr-footer')),
+      canvas.getAllByRole('img').find((img) => img.className.includes('soc-footer')),
+      canvas.getAllByRole('img').find((img) => img.className.includes('iso-footer')),
+      canvas.getAllByRole('img').find((img) => img.className.includes('fhir-footer')),
+    ];
+    for (const badge of badges) {
+      await expect(badge).toBeDefined();
+      await expect(getComputedStyle(badge as Element).filter).toContain('brightness');
+    }
+
+    // The FDA/21 CFR mark ships on its own opaque white plate already, so it
+    // reads fine on either theme and must NOT get the same filter - that
+    // would wash its black wordmark out against its own white background.
+    const fda = canvas.getAllByRole('img').find((img) => img.className.includes('fda-footer'));
+    await expect(getComputedStyle(fda as Element).filter).not.toContain('brightness');
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          'The certification strip is the one part of the footer with real third-party marks in it, ' +
+          "so this recolours the existing images (grayscale + brightness, the same filter AuthShell's " +
+          'permanently-dark brand panel already uses for the identical problem) rather than swapping ' +
+          'in a redrawn "dark" logo for anything AICPA/ISO/HL7 actually issued.',
       },
     },
   },


### PR DESCRIPTION
## Summary
- The GDPR/SOC 2/ISO 27001/FHIR marks in the footer are dark ink on a transparent background; against the dark-theme footer background they become illegible.
- Reuses the `filter: grayscale(1) brightness(2.2)` technique already applied inline in `AuthShell.tsx` to these exact same official marks (for its own permanently-dark brand panel), so no mark is redrawn, replaced, or fabricated — only the on-screen rendering of the existing pixels is recoloured. The FDA mark already carries its own opaque light background and is deliberately excluded.
- Added a Storybook story that pins the dark theme and asserts the filter via `getComputedStyle` on each badge, so the fix has story coverage.

## Impact area
`apps/frontend` only: `Footer.css`, `Footer.stories.tsx`.

## Validation performed
- Verified visually in Storybook (both themes) — dark theme badges legible, light theme pixel-identical to before.
- Verified via direct `getComputedStyle` assertions against the live Storybook iframe in both themes.
- `npx tsc --noemit` (frontend) — 0 errors.
- `npx eslint` on both touched files — 0 errors.
- Pre-push hook (full monorepo lint + type-check, 17/17 tasks) passed.