### PR TITLE
fix(backend): net refunds from invoice paid totals

### DIFF
--- a/apps/backend/src/services/finance/payment.ts
+++ b/apps/backend/src/services/finance/payment.ts
@@ -12,7 +12,7 @@ import Stripe from "stripe";
 import { prisma } from "src/config/prisma";
 import logger from "src/utils/logger";
 import { FinanceEventService } from "./events";
-import { roundMoney } from "./pricing";
+import { getNetPaymentAmount, roundMoney } from "./pricing";
 import {
   fromStripeMinorUnits,
   toStripeMinorUnits,
@@ -213,8 +213,17 @@ export const getInvoiceFinancialSummary = async (
 ): Promise<InvoiceFinancialSummary> => {
   const [payments, creditNotes] = await Promise.all([
     prisma.payment.findMany({
-      where: { invoiceId, status: "SUCCEEDED" },
-      select: { amount: true },
+      where: {
+        invoiceId,
+        status: { in: ["SUCCEEDED", "PARTIALLY_REFUNDED", "REFUNDED"] },
+      },
+      select: {
+        amount: true,
+        refunds: {
+          where: { status: "SUCCEEDED" },
+          select: { amount: true, status: true },
+        },
+      },
     }),
     prisma.creditNote.findMany({
       where: { invoiceId, status: "ISSUED" },
@@ -223,7 +232,7 @@ export const getInvoiceFinancialSummary = async (
   ]);
 
   const paid = roundMoney(
-    payments.reduce((sum, payment) => sum + payment.amount, 0),
+    payments.reduce((sum, payment) => sum + getNetPaymentAmount(payment), 0),
   );
   const credited = roundMoney(
     creditNotes.reduce((sum, creditNote) => sum + creditNote.amount, 0),

--- a/apps/backend/src/services/finance/pricing.ts
+++ b/apps/backend/src/services/finance/pricing.ts
@@ -45,6 +45,18 @@ const MONEY_SCALE = 100;
 export const roundMoney = (value: number): number =>
   Math.round((value + Number.EPSILON) * MONEY_SCALE) / MONEY_SCALE;
 
+export const getNetPaymentAmount = (payment: {
+  amount: number;
+  refunds?: Array<{ amount: number; status: string }>;
+}): number => {
+  const refunded = roundMoney(
+    (payment.refunds ?? [])
+      .filter((refund) => refund.status === "SUCCEEDED")
+      .reduce((sum, refund) => sum + refund.amount, 0),
+  );
+  return roundMoney(Math.max(0, payment.amount - refunded));
+};
+
 const normalizePositiveNumber = (value: number | null | undefined): number => {
   if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
     return 0;

--- a/apps/backend/src/services/invoice.service.ts
+++ b/apps/backend/src/services/invoice.service.ts
@@ -15,6 +15,7 @@ import {
 import {
   calculateInvoiceDiscountPercentOfBase,
   calculateInvoicePricing,
+  getNetPaymentAmount,
   roundMoney,
   type InvoiceDiscountInput as PricingInvoiceDiscountInput,
 } from "./finance/pricing";
@@ -494,7 +495,7 @@ const computeInvoiceFinancialDetails = (
     : [];
 
   const actualCashPaid = roundMoney(
-    payments.reduce((sum, payment) => sum + payment.amount, 0),
+    payments.reduce((sum, payment) => sum + getNetPaymentAmount(payment), 0),
   );
   const depositRecordedAmount = roundMoney(invoice.depositCollectedAmount ?? 0);
   const credited = roundMoney(

--- a/apps/backend/test/services/finance.payment.test.ts
+++ b/apps/backend/test/services/finance.payment.test.ts
@@ -4,6 +4,7 @@ import {
   FinancePaymentService,
   __setFinanceStripeClientForTests,
   cancelOpenCheckoutSessionAttempts,
+  getInvoiceFinancialSummary,
   resolveStripeConnectedAccountId,
 } from "../../src/services/finance/payment";
 import { prisma } from "src/config/prisma";
@@ -75,6 +76,33 @@ describe("FinancePaymentService", () => {
     });
     process.env.STRIPE_SECRET_KEY = "sk_test_mock";
     process.env.APP_URL = "https://app.test";
+  });
+
+  it("nets successful refunds when summarising invoice payments", async () => {
+    (prisma.payment.findMany as jest.Mock).mockResolvedValueOnce([
+      { amount: 200, refunds: [{ amount: 50, status: "SUCCEEDED" }] },
+      { amount: 25, refunds: [{ amount: 30, status: "SUCCEEDED" }] },
+    ]);
+    (prisma.creditNote.findMany as jest.Mock).mockResolvedValueOnce([]);
+
+    await expect(getInvoiceFinancialSummary("inv_1", 200)).resolves.toEqual({
+      paid: 150,
+      credited: 0,
+      balance: 50,
+    });
+    expect(prisma.payment.findMany).toHaveBeenCalledWith({
+      where: {
+        invoiceId: "inv_1",
+        status: { in: ["SUCCEEDED", "PARTIALLY_REFUNDED", "REFUNDED"] },
+      },
+      select: {
+        amount: true,
+        refunds: {
+          where: { status: "SUCCEEDED" },
+          select: { amount: true, status: true },
+        },
+      },
+    });
   });
 
   it("creates provider-backed payment attempts", async () => {

--- a/apps/backend/test/services/invoice.service.test.ts
+++ b/apps/backend/test/services/invoice.service.test.ts
@@ -2503,6 +2503,19 @@ describe("InvoiceService", () => {
             createdAt: new Date("2026-06-18T11:00:00.000Z"),
             updatedAt: new Date("2026-06-18T11:00:00.000Z"),
           },
+          {
+            id: "refund_failed",
+            paymentId: "pay_1",
+            provider: "STRIPE",
+            providerRefundId: null,
+            amount: 25,
+            currency: "usd",
+            status: "FAILED",
+            reason: null,
+            rawProviderPayload: null,
+            createdAt: new Date("2026-06-18T12:00:00.000Z"),
+            updatedAt: new Date("2026-06-18T12:00:00.000Z"),
+          },
         ],
         createdAt: new Date("2026-06-18T09:00:00.000Z"),
         updatedAt: new Date("2026-06-18T10:00:00.000Z"),
@@ -2540,18 +2553,18 @@ describe("InvoiceService", () => {
     expect(result.invoice.settlementSummary).toEqual(
       expect.objectContaining({
         invoiceTotal: 100,
-        cashPaid: 50,
+        cashPaid: 40,
         credited: 10,
-        effectivePaid: 50,
-        balance: 40,
+        effectivePaid: 40,
+        balance: 50,
       }),
     );
     expect(result.invoice.settlementSummary.lineAllocations).toEqual([
       expect.objectContaining({
         id: "line_1",
-        cashApplied: 50,
+        cashApplied: 40,
         creditApplied: 10,
-        remaining: 40,
+        remaining: 50,
       }),
     ]);
   });
@@ -3809,7 +3822,12 @@ describe("InvoiceService", () => {
     ];
     (prisma.invoice.findMany as jest.Mock).mockResolvedValueOnce(invoices);
     (prisma.payment.findMany as jest.Mock).mockResolvedValueOnce([
-      { id: "pay_a", invoiceId: "inv_a", amount: 50, refunds: [] },
+      {
+        id: "pay_a",
+        invoiceId: "inv_a",
+        amount: 50,
+        refunds: [{ amount: 15, status: "SUCCEEDED" }],
+      },
     ]);
     (prisma.creditNote.findMany as jest.Mock).mockResolvedValueOnce([
       { id: "cn_a", invoiceId: "inv_a", amount: 20 },
@@ -3817,9 +3835,9 @@ describe("InvoiceService", () => {
 
     const results = await InvoiceService.listForOrganisation(organisationId);
 
-    // inv_a: 200 total, 50 paid, 20 credited -> 130 outstanding.
+    // inv_a: 200 total, 35 net paid, 20 credited -> 145 outstanding.
     expect(results[0].settlementSummary).toEqual(
-      expect.objectContaining({ cashPaid: 50, credited: 20, balance: 130 }),
+      expect.objectContaining({ cashPaid: 35, credited: 20, balance: 145 }),
     );
     // inv_b has neither, so it still owes the whole amount.
     expect(results[1].settlementSummary).toEqual(


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [ ] All existing tests and lints pass.

## What is the current behavior?

Invoice settlement calculations count the original amount of successful payments without subtracting successful refunds. A fully refunded payment can also be omitted from one summary path while remaining counted at its gross amount in another, producing inconsistent paid and balance totals.

## What is the new behavior?

Invoice financial summaries use a shared calculation that subtracts successful refunds from each payment and floors the result at zero. Both invoice detail/list settlement data and the reusable finance summary now include succeeded, partially refunded, and refunded payments and report their net paid amount consistently.

Added coverage for partial refunds, failed refunds, and refunds larger than the original payment. The two affected backend suites pass (281 tests), backend type-check and build pass, and the repository-wide pre-push lint and type-check gates pass. The complete backend test suite requires the repository's Redis-backed test environment and was not completed locally.

## Related Issue(s)

Fixes #3138
