### PR TITLE
fix(backend): atomic decrement, transactions, and allocation guard for inventory consumption

### DIFF
--- a/apps/backend/src/services/inventory-consumption.service.ts
+++ b/apps/backend/src/services/inventory-consumption.service.ts
@@ -1170,7 +1170,17 @@ const applyInventoryConsumption = async (
   params: InventoryConsumptionApplyParams,
 ) => {
   const item = await requireInventoryItemForAdjustment(tx, params);
-  if ((item.onHand ?? 0) < params.quantity) {
+  // A NORMAL-source consumption must not eat into stock already reserved for
+  // someone else via InventoryAllocationService.allocateStock (the allocation
+  // path itself enforces onHand-allocated>=quantity; this guard mirrors it).
+  // An ALLOCATED-source consumption is drawing down that same reservation, so
+  // it is checked against onHand alone - finalizeInventoryAdjustment below
+  // reduces `allocated` for that case.
+  const availableForConsumption =
+    params.stockSource === "ALLOCATED"
+      ? (item.onHand ?? 0)
+      : (item.onHand ?? 0) - (item.allocated ?? 0);
+  if (availableForConsumption < params.quantity) {
     throw new InventoryConsumptionServiceError("Insufficient stock", 400);
   }
 
@@ -1195,7 +1205,7 @@ const applyInventoryConsumption = async (
 
     await tx.inventoryBatch.update({
       where: { id: batch.id },
-      data: { quantity: available - consume },
+      data: { quantity: { decrement: consume } },
     });
 
     await tx.inventoryStockMovement.create({

--- a/apps/backend/src/services/inventory.service.ts
+++ b/apps/backend/src/services/inventory.service.ts
@@ -614,17 +614,20 @@ export interface InventoryTurnoverRow {
   status: InventoryTurnoverStatus;
 }
 
+type PrismaClientOrTx = typeof prisma | Prisma.TransactionClient;
+
 /**
  * HELPER: Recompute onHand and allocated from batches
  */
 const recomputeStockFromBatches = async (
   itemId: string,
+  client: PrismaClientOrTx = prisma,
 ): Promise<{
   onHand: number;
   allocated: number;
   nearestExpiry: Date | null;
 }> => {
-  const batches = await prisma.inventoryBatch.findMany({
+  const batches = await client.inventoryBatch.findMany({
     where: { itemId },
   });
 
@@ -659,8 +662,11 @@ const ensureObjectId = (id: string, fieldName = "id"): string => {
 /**
  * HELPER: log stock movment
  */
-const logMovement = async (payload: StockMovementInput) => {
-  await prisma.inventoryStockMovement.create({
+const logMovement = async (
+  payload: StockMovementInput,
+  client: PrismaClientOrTx = prisma,
+) => {
+  await client.inventoryStockMovement.create({
     data: {
       itemId: payload.itemId ?? undefined,
       batchId: payload.batchId ?? undefined,
@@ -1985,37 +1991,50 @@ export const InventoryService = {
       throw new InventoryServiceError("quantity must be > 0", 400);
     }
 
-    const item = await prisma.inventoryItem.findFirst({
-      where: { id: safeItemId, organisationId: safeOrganisationId },
-    });
-    if (!item) {
-      throw new InventoryServiceError("Inventory item not found", 404);
-    }
-
-    if ((item.onHand ?? 0) < input.quantity) {
-      throw new InventoryServiceError("Insufficient stock", 400);
-    }
-
-    const batches = await prisma.inventoryBatch.findMany({
-      where: { itemId: safeItemId },
-      orderBy: [{ expiryDate: "asc" }, { id: "asc" }],
-    });
-
-    const plan = planFifoConsumption(batches, input.quantity);
-    for (const { index, newQuantity } of plan) {
-      const batch = batches[index];
-      await prisma.inventoryBatch.update({
-        where: { id: batch.id },
-        data: { quantity: newQuantity },
+    const updated = await prisma.$transaction(async (tx) => {
+      const item = await tx.inventoryItem.findFirst({
+        where: { id: safeItemId, organisationId: safeOrganisationId },
       });
-    }
+      if (!item) {
+        throw new InventoryServiceError("Inventory item not found", 404);
+      }
 
-    // Reservations are tracked on the item (see allocateStock), not on batches,
-    // so consumption must not recompute `allocated` from the batch rows.
-    const { onHand } = await recomputeStockFromBatches(safeItemId);
-    const updated = await prisma.inventoryItem.update({
-      where: { id: safeItemId },
-      data: { onHand },
+      if ((item.onHand ?? 0) < input.quantity) {
+        throw new InventoryServiceError("Insufficient stock", 400);
+      }
+
+      const batches = await tx.inventoryBatch.findMany({
+        where: { itemId: safeItemId },
+        orderBy: [{ expiryDate: "asc" }, { id: "asc" }],
+      });
+
+      const plan = planFifoConsumption(batches, input.quantity);
+      for (const { index, newQuantity } of plan) {
+        const batch = batches[index];
+        const consumed = (batch.quantity ?? 0) - newQuantity;
+        await tx.inventoryBatch.update({
+          where: { id: batch.id },
+          data: { quantity: { decrement: consumed } },
+        });
+        await logMovement(
+          {
+            itemId: safeItemId,
+            batchId: batch.id,
+            change: -consumed,
+            reason: input.reason,
+            referenceId: input.referenceId,
+          },
+          tx,
+        );
+      }
+
+      // Reservations are tracked on the item (see allocateStock), not on batches,
+      // so consumption must not recompute `allocated` from the batch rows.
+      const { onHand } = await recomputeStockFromBatches(safeItemId, tx);
+      return tx.inventoryItem.update({
+        where: { id: safeItemId },
+        data: { onHand },
+      });
     });
 
     return {

--- a/apps/backend/test/services/inventory-consumption.service.test.ts
+++ b/apps/backend/test/services/inventory-consumption.service.test.ts
@@ -215,6 +215,21 @@ describe("InventoryConsumptionService", () => {
     });
 
     expect(events).toHaveLength(1);
+    // Batch decrements must be atomic Prisma `decrement` writes, not a
+    // literal computed value - otherwise a concurrent consumption of the same
+    // batch produces a lost update even inside this transaction.
+    expect(mockedPrisma.inventoryBatch.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "batch-1" },
+        data: { quantity: { decrement: 2 } },
+      }),
+    );
+    expect(mockedPrisma.inventoryBatch.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { id: "batch-2" },
+        data: { quantity: { decrement: 1 } },
+      }),
+    );
     expect(mockedPrisma.inventoryItem.update).toHaveBeenCalledWith(
       expect.objectContaining({
         data: { onHand: 3 },
@@ -2674,6 +2689,36 @@ describe("InventoryConsumptionService", () => {
         ],
       }),
     ).rejects.toThrow("Insufficient stock");
+  });
+
+  // onHand(10) alone would pass a quantity of 8, but 5 of that onHand is
+  // already reserved via InventoryAllocationService.allocateStock for a
+  // different patient/encounter - a NORMAL-source consumption must respect
+  // that reservation the same way allocateStock's own guard does.
+  it("refuses a NORMAL-source consumption that would dispense allocated (reserved) stock", async () => {
+    mockedPrisma.inventoryItem.findFirst.mockResolvedValueOnce({
+      id: "item-reserved",
+      organisationId: "org-1",
+      onHand: 10,
+      allocated: 5,
+    });
+
+    await expect(
+      InventoryConsumptionService.consume({
+        organisationId: "org-1",
+        sourceType: "PRESCRIPTION",
+        sourceId: "rx-reserved",
+        metadata: { dispenseStockSource: "NORMAL" },
+        lines: [
+          {
+            sourceLineKey: "line-1",
+            inventoryItemId: "item-reserved",
+            quantity: 8,
+          },
+        ],
+      }),
+    ).rejects.toThrow("Insufficient stock");
+    expect(mockedPrisma.inventoryBatch.update).not.toHaveBeenCalled();
   });
 
   it("throws when batches cannot cover the full requested consumption", async () => {

--- a/apps/backend/test/services/inventory.service.test.ts
+++ b/apps/backend/test/services/inventory.service.test.ts
@@ -20,6 +20,7 @@ import {
 
 jest.mock("src/config/prisma", () => ({
   prisma: {
+    $transaction: jest.fn(),
     organizationBilling: {
       findUnique: jest.fn(),
     },
@@ -82,6 +83,10 @@ jest.mock("../../src/services/inventory.catalog", () => ({
 describe("Inventory service", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      async (callback: unknown) =>
+        typeof callback === "function" ? callback(prisma) : undefined,
+    );
     (prisma.organizationBilling.findUnique as jest.Mock).mockResolvedValue({
       currency: "usd",
     });
@@ -1309,6 +1314,11 @@ describe("Inventory service guards, helpers, and branch paths", () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+
+    (prisma.$transaction as jest.Mock).mockImplementation(
+      async (callback: unknown) =>
+        typeof callback === "function" ? callback(prisma) : undefined,
+    );
 
     mockOf(calculateInventoryStockStatus).mockReturnValue("In stock");
     mockOf(calculatePricingMetrics).mockReturnValue({
@@ -2630,11 +2640,68 @@ describe("Inventory service guards, helpers, and branch paths", () => {
       );
 
       expect(mockOf(prisma.inventoryBatch.update).mock.calls).toEqual([
-        [{ where: { id: "first" }, data: { quantity: 0 } }],
-        [{ where: { id: "second" }, data: { quantity: 3 } }],
+        [{ where: { id: "first" }, data: { quantity: { decrement: 4 } } }],
+        [{ where: { id: "second" }, data: { quantity: { decrement: 2 } } }],
       ]);
       expect(updated.onHand).toBe(10);
       expect(updated._id).toBe("item-1");
+    });
+
+    it("logs a stock movement for every batch it drains", async () => {
+      mockOf(prisma.inventoryItem.findFirst).mockResolvedValue(
+        itemRow({ onHand: 10 }),
+      );
+      mockOf(prisma.inventoryBatch.findMany)
+        .mockResolvedValueOnce([
+          batchRow({ id: "batch-a", quantity: 4 }),
+          batchRow({ id: "batch-b", quantity: 6 }),
+        ])
+        .mockResolvedValueOnce([
+          batchRow({ id: "batch-a", quantity: 0 }),
+          batchRow({ id: "batch-b", quantity: 4 }),
+        ]);
+      mockOf(prisma.inventoryItem.update).mockResolvedValue(
+        itemRow({ onHand: 4 }),
+      );
+
+      await InventoryService.consumeStock(
+        {
+          itemId: "item-1",
+          quantity: 6,
+          reason: "APPOINTMENT_USAGE",
+          referenceId: "appt-1",
+        },
+        "org-1",
+      );
+
+      expect(mockOf(prisma.inventoryStockMovement.create).mock.calls).toEqual([
+        [
+          {
+            data: {
+              itemId: "item-1",
+              batchId: "batch-a",
+              change: -4,
+              reason: "APPOINTMENT_USAGE",
+              referenceId: "appt-1",
+              userId: undefined,
+              createdAt: expect.any(Date),
+            },
+          },
+        ],
+        [
+          {
+            data: {
+              itemId: "item-1",
+              batchId: "batch-b",
+              change: -2,
+              reason: "APPOINTMENT_USAGE",
+              referenceId: "appt-1",
+              userId: undefined,
+              createdAt: expect.any(Date),
+            },
+          },
+        ],
+      ]);
     });
   });
 


### PR DESCRIPTION
Fixes bugs 1, 2, 3, and 5 from #3142:
- `applyInventoryConsumption` wrote a literal computed batch quantity instead of an atomic Prisma `decrement`, losing updates under concurrent dispenses.
- `InventoryService.consumeStock` ran with no transaction at all and never logged a stock movement, unlike every other stock-changing path.
- The insufficient-stock guard only checked `onHand`, letting a NORMAL-source consumption dispense stock already reserved via `allocateStock`.

Bug 4 (controlled-substance register wiring) is not included: `ControlledSubstanceLogService.create` requires a `deaSchedule` and `unit` per entry that `InventoryItem` does not store anywhere in the schema, and `amountDrawn`/`amountAdministered`/`amountWasted` are real per-administration clinical quantities a pharmacy dispense event can't supply — needs a schema/design decision, not wiring.

## Test plan
- [x] `npx jest test/services/inventory.service.test.ts test/services/inventory-consumption.service.test.ts` — 278/278
- [x] Full backend suite: 499 suites / 11841 tests, all passed
- [x] `tsc --noEmit` clean
- [x] `eslint` on changed files — 0 errors (3 pre-existing warnings, unrelated lines)