### PR TITLE
fix(frontend): stub bot verification in SignUp Storybook

### DIFF
--- a/apps/frontend/.storybook/main.ts
+++ b/apps/frontend/.storybook/main.ts
@@ -58,6 +58,7 @@ const config: StorybookConfigWithFavicon = {
         }));
 
     viteConfig.resolve.alias = [
+      { find: /^next\/script$/, replacement: path.join(here, 'mocks/nextScript.tsx') },
       ...inherited,
       { find: /^@\/features\//, replacement: `${path.join(src, 'app/features')}/` },
       { find: /^@\/ui\//, replacement: `${path.join(src, 'app/ui')}/` },

--- a/apps/frontend/.storybook/mocks/nextScript.tsx
+++ b/apps/frontend/.storybook/mocks/nextScript.tsx
@@ -1,0 +1,3 @@
+const NextScript = () => null;
+
+export default NextScript;

--- a/apps/frontend/src/app/__tests__/storybook/mainViteAlias.test.ts
+++ b/apps/frontend/src/app/__tests__/storybook/mainViteAlias.test.ts
@@ -7,6 +7,7 @@
  * that shows up later as one story failing to render, far from its cause.
  */
 import config from '../../../../.storybook/main';
+import NextScript from '../../../../.storybook/mocks/nextScript';
 
 type AliasEntry = { find: string | RegExp; replacement: string };
 
@@ -66,7 +67,15 @@ describe('.storybook viteFinal alias handling', () => {
     expect(entry?.replacement.endsWith('mocks/mediaSources.ts')).toBe(true);
   });
 
+  it('replaces next/script with the no-op Storybook implementation', () => {
+    const out = run(undefined);
+    const entry = out.find((a) => String(a.find) === '/^next\\/script$/');
+
+    expect(entry?.replacement.endsWith('mocks/nextScript.tsx')).toBe(true);
+    expect(NextScript()).toBeNull();
+  });
+
   it('copes with no inherited aliases at all', () => {
-    expect(run(undefined).length).toBe(6);
+    expect(run(undefined).length).toBe(7);
   });
 });

--- a/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
+++ b/apps/frontend/src/app/features/auth/pages/SignUp/SignUp.stories.tsx
@@ -14,6 +14,26 @@ import { STATS_CACHE_KEY, STATS_TS_KEY } from '@/app/features/marketing/site/use
 
 const CLINIC_ROLE = 'A veterinary clinic, practice, or hospital';
 const DEVELOPER_ROLE = 'A developer';
+const TURNSTILE_STORY_SITE_KEY = 'storybook-test-site-key';
+let lastTurnstileToken = '';
+
+const installTurnstileStub = () => {
+  const storyWindow = globalThis.window as Window & { turnstile?: unknown };
+  const previousTurnstile = storyWindow.turnstile;
+  storyWindow.turnstile = {
+    render: (_container: HTMLElement, options: { callback: (token: string) => void }) => {
+      const token = 'storybook-test-token';
+      lastTurnstileToken = token;
+      options.callback(token);
+      return 'storybook-widget';
+    },
+    reset: () => undefined,
+    remove: () => undefined,
+  };
+  return () => {
+    storyWindow.turnstile = previousTurnstile;
+  };
+};
 
 /**
  * Seeds the marketing-stats session cache that the auth brand panel reads through
@@ -48,6 +68,7 @@ const clearSignUpDraft = () => {
 const meta = {
   title: 'Auth/SignUp',
   component: SignUp,
+  args: { turnstileSiteKey: TURNSTILE_STORY_SITE_KEY },
   parameters: {
     layout: 'fullscreen',
     /* Stops the preview decorator stamping a SECOND `data-yc-app` around the
@@ -84,8 +105,11 @@ const meta = {
   },
   tags: ['autodocs'],
   beforeEach: () => {
+    lastTurnstileToken = '';
+    const restoreTurnstile = installTurnstileStub();
     seedGithubStats();
     clearSignUpDraft();
+    return restoreTurnstile;
   },
 } satisfies Meta<typeof SignUp>;
 
@@ -96,6 +120,8 @@ export const Default: Story = {
   name: 'Clinic pane (default)',
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
+
+    await waitFor(() => expect(lastTurnstileToken).toBe('storybook-test-token'));
 
     const role = canvas.getByRole('button', { name: `I am: ${CLINIC_ROLE}` });
     await expect(role).toHaveTextContent(CLINIC_ROLE);


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

The production Storybook renders the SignUp stories without the deployed Turnstile configuration. That starts the story with a bot-verification error and allows the real external verification script to be loaded repeatedly while stories are exercised.

## What is the new behavior?

Storybook aliases `next/script` to a no-op implementation and the SignUp story installs a deterministic in-window Turnstile stub. The default story asserts that the stub delivered its verification token before continuing its interaction checks. Production application behavior is unchanged.

Validation performed:

- Frontend TypeScript check
- Frontend and full monorepo lint
- Full monorepo type-check
- Focused Jest: 2 suites, 30 tests, 100% coverage for the new Storybook mock
- Mutation checks: broken alias failed 1/7; empty Turnstile token failed the SignUp Storybook suite 2/7
- Production Storybook build
- Filtered Chromium Storybook run: 2 suites, 7 tests
- Aikido scan: zero issues across all four changed files

The local Sonar agentic scan could not run because elevated source analysis was not approved in this environment; hosted Sonar remains required on this PR.

## Related Issue(s)

Fixes #3067
