### PR TITLE
fix(backend): correct recurring-task and reminder scheduling bugs

### DIFF
--- a/apps/backend/src/services/task.recurrence.engine.ts
+++ b/apps/backend/src/services/task.recurrence.engine.ts
@@ -4,7 +4,13 @@ import utc from "dayjs/plugin/utc.js";
 import timezone from "dayjs/plugin/timezone.js";
 import cronParser from "cron-parser";
 
-import { Prisma, TaskAudience, TaskSource, TaskStatus } from "@prisma/client";
+import {
+  Prisma,
+  TaskAudience,
+  TaskPriority,
+  TaskSource,
+  TaskStatus,
+} from "@prisma/client";
 import { prisma } from "src/config/prisma";
 
 dayjs.extend(utc);
@@ -36,9 +42,18 @@ const computeNextDueAt = (
     case "ONCE":
       return null;
     case "DAILY":
-      return base.add(1, "day").toDate();
-    case "WEEKLY":
-      return base.add(1, "week").toDate();
+    case "WEEKLY": {
+      // `.add()` on a dayjs-tz instant preserves the previous instant's UTC
+      // offset instead of recomputing it for the destination date, so it
+      // silently shifts local wall-clock time across a DST transition.
+      // Re-parsing the target calendar date as a naive local string keeps
+      // the same local time of day regardless of offset changes.
+      const unit = recurrenceType === "DAILY" ? "day" : "week";
+      const target = base.add(1, unit).format("YYYY-MM-DDTHH:mm:ss.SSS");
+      return timezone
+        ? dayjs.tz(target, timezone).toDate()
+        : dayjs(target).toDate();
+    }
     case "CUSTOM":
       if (!cronExpression) return null;
       try {
@@ -107,8 +122,10 @@ const cloneFromMasterPrisma = (
     libraryTaskId: string | null;
     templateId: string | null;
     category: string;
+    subcategory: string | null;
     name: string;
     description: string | null;
+    additionalNotes: string | null;
     medication: Prisma.InputJsonValue | null;
     observationToolId: string | null;
     dueAt: Date;
@@ -117,6 +134,8 @@ const cloneFromMasterPrisma = (
     reminder: Prisma.InputJsonValue | null;
     syncWithCalendar: boolean | null;
     attachments: Prisma.InputJsonValue | null;
+    assignedGroupId: string | null;
+    priority: TaskPriority | null;
   },
   dueAt: Date,
 ) => ({
@@ -131,12 +150,16 @@ const cloneFromMasterPrisma = (
   libraryTaskId: master.libraryTaskId ?? undefined,
   templateId: master.templateId ?? undefined,
   category: master.category,
+  subcategory: master.subcategory ?? undefined,
   name: master.name,
   description: master.description ?? undefined,
+  additionalNotes: master.additionalNotes ?? undefined,
   medication: master.medication ?? undefined,
   observationToolId: master.observationToolId ?? undefined,
   dueAt,
   timezone: master.timezone ?? undefined,
+  assignedGroupId: master.assignedGroupId ?? undefined,
+  priority: master.priority ?? undefined,
   recurrence: (() => {
     const recurrenceBase =
       (master.recurrence as Record<string, Prisma.InputJsonValue> | null) ?? {};
@@ -148,7 +171,16 @@ const cloneFromMasterPrisma = (
       endDate: recurrenceBase["endDate"] ?? undefined,
     } as Prisma.InputJsonValue;
   })(),
-  reminder: master.reminder ?? undefined,
+  // Reset the sent/notification marker for the new occurrence — copying the
+  // parent's reminder verbatim would carry over a scheduledNotificationId
+  // set once the parent's own reminder fired, which makes the reminder
+  // worker treat this brand-new occurrence as already sent.
+  reminder: master.reminder
+    ? {
+        ...(master.reminder as Record<string, Prisma.InputJsonValue>),
+        scheduledNotificationId: undefined,
+      }
+    : undefined,
   syncWithCalendar: master.syncWithCalendar ?? undefined,
   attachments: master.attachments ?? undefined,
   status: "PENDING" as TaskStatus,
@@ -159,9 +191,15 @@ export const TaskRecurrenceEngine = {
     const now = dayjs();
     const horizon = now.add(MAX_HORIZON_DAYS, "day");
 
+    // Deliberately not filtered on the master row's own `status`: the master
+    // row IS occurrence #1, so cancelling only that occurrence (scope
+    // "THIS") would otherwise stop the whole series from generating any
+    // further children. A series-level stop is expressed via
+    // `recurrence.endDate` (set by the THIS_AND_FOLLOWING/ALL cancel paths
+    // in TaskService), which `getNextOccurrence` already honors below.
     const masters = await prisma.task.findMany({
       where: {
-        status: { not: "CANCELLED" },
+        recurrence: { path: ["isMaster"], equals: true },
       },
     });
 

--- a/apps/backend/src/services/task.reminder.engine.ts
+++ b/apps/backend/src/services/task.reminder.engine.ts
@@ -24,10 +24,18 @@ export const TaskReminderEngine = {
   async run() {
     const nowUtc = dayjs.utc();
 
+    // Bound the scan with a lookback grace window rather than an upper
+    // bound of "now": a `dueAt >= now` filter excludes a task the instant
+    // its due time passes, which for a zero-offset reminder (fire at due
+    // time) means no worker tick ever sees it - the tick just before due
+    // finds it too early, and the tick just after finds it already
+    // filtered out. `reminder.scheduledNotificationId` (checked below)
+    // is what actually stops a reminder from resending, so the query only
+    // needs to keep the scan bounded, not gate delivery.
     const tasks = await prisma.task.findMany({
       where: {
         status: { in: ["PENDING", "IN_PROGRESS"] },
-        dueAt: { gte: nowUtc.toDate() },
+        dueAt: { gte: nowUtc.subtract(1, "day").toDate() },
       },
     });
 

--- a/apps/backend/src/services/task.schedule.engine.ts
+++ b/apps/backend/src/services/task.schedule.engine.ts
@@ -208,10 +208,6 @@ const materializeSchedule = async (
   },
   now: Date,
 ) => {
-  if (isNonEmptyStringArray(schedule.generatedTaskIds)) {
-    return;
-  }
-
   if (
     !Array.isArray(schedule.materializedSeeds) ||
     schedule.materializedSeeds.length === 0
@@ -219,21 +215,45 @@ const materializeSchedule = async (
     return;
   }
 
-  const seeds = schedule.materializedSeeds.map(parseSeed);
-  const generatedTaskIds: string[] = [];
+  // `generatedTaskIds` is persisted incrementally (one write per seed)
+  // rather than once at the end of the loop. Previously a mid-loop failure
+  // (e.g. seed 2 of 2 throwing) left the array empty even though seed 1's
+  // task row had already been created, so a retry re-ran every seed from
+  // scratch and duplicated the ones that had already succeeded. Persisting
+  // after each success lets a retry resume from the first seed that never
+  // got an id, instead of redoing already-generated ones.
+  const generatedTaskIds: string[] = isNonEmptyStringArray(
+    schedule.generatedTaskIds,
+  )
+    ? [...schedule.generatedTaskIds]
+    : [];
 
-  for (const seed of seeds) {
+  // Compare against the raw seed count before parsing: a schedule that is
+  // already fully materialized must stay a no-op even if its stored seeds
+  // are old/invalid shapes, exactly as before this change.
+  if (generatedTaskIds.length >= schedule.materializedSeeds.length) {
+    return;
+  }
+
+  const seeds = schedule.materializedSeeds.map(parseSeed);
+
+  for (let index = generatedTaskIds.length; index < seeds.length; index++) {
     const task = await TaskService.createFromWorkflowSeed(
-      toWorkflowSeedInput(seed),
+      toWorkflowSeedInput(seeds[index]),
       { notify: false },
     );
     generatedTaskIds.push(task.id);
+
+    await prisma.taskSchedule.update({
+      where: { id: schedule.id },
+      data: { generatedTaskIds },
+    });
   }
 
   await prisma.taskSchedule.update({
     where: { id: schedule.id },
     data: {
-      generatedTaskIds: generatedTaskIds,
+      generatedTaskIds,
       status: scheduleStatusForTemplateKind(schedule.templateKind),
       completedAt:
         schedule.templateKind === TemplateKind.TASK_TEMPLATE ? now : null,

--- a/apps/backend/src/services/task.service.ts
+++ b/apps/backend/src/services/task.service.ts
@@ -1997,6 +1997,39 @@ export const TaskService = {
           },
         });
       }
+
+      if (normalizedScope === "ALL") {
+        // The recurrence engine no longer infers "stop the series" from the
+        // master row's own occurrence status (cancelling only occurrence #1
+        // must not end the series - see task.recurrence.engine.ts), so an
+        // explicit series-wide cancel has to end it via recurrence.endDate
+        // instead, the same mechanism THIS_AND_FOLLOWING already uses.
+        const masterRow = await tx.task.findUnique({
+          where: { id: seriesMasterId },
+        });
+        if (masterRow) {
+          await tx.task.update({
+            where: { id: seriesMasterId },
+            data: {
+              recurrence: mergeRecurrence(masterRow.recurrence, {
+                type:
+                  (
+                    masterRow.recurrence as {
+                      type?: TaskRecurrenceType;
+                    } | null
+                  )?.type ?? "ONCE",
+                endDate: new Date(),
+                cronExpression:
+                  (
+                    masterRow.recurrence as {
+                      cronExpression?: string | null;
+                    } | null
+                  )?.cronExpression ?? null,
+              }),
+            },
+          });
+        }
+      }
     });
   },
 

--- a/apps/backend/test/services/task.recurrence.engine.test.ts
+++ b/apps/backend/test/services/task.recurrence.engine.test.ts
@@ -13,7 +13,41 @@ jest.mock("src/config/prisma", () => ({
 
 import { TaskRecurrenceEngine } from "src/services/task.recurrence.engine";
 
-const master = (cronExpression: string) => ({
+type MasterFixture = {
+  id: string;
+  organisationId: string | null;
+  appointmentId: string | null;
+  patientId: string | null;
+  createdBy: string;
+  assignedBy: string | null;
+  assignedTo: string;
+  audience: string;
+  source: string;
+  libraryTaskId: string | null;
+  templateId: string | null;
+  category: string;
+  subcategory: string | null;
+  name: string;
+  description: string | null;
+  additionalNotes: string | null;
+  medication: unknown;
+  observationToolId: string | null;
+  dueAt: Date;
+  timezone: string | null;
+  status: string;
+  recurrence: { isMaster: boolean; type: string; cronExpression?: string };
+  reminder: {
+    enabled: boolean;
+    offsetMinutes: number;
+    scheduledNotificationId?: string;
+  } | null;
+  syncWithCalendar: boolean | null;
+  attachments: unknown;
+  assignedGroupId: string | null;
+  priority: string | null;
+};
+
+const master = (cronExpression: string): MasterFixture => ({
   id: "task-1",
   organisationId: "org-1",
   appointmentId: null,
@@ -26,8 +60,10 @@ const master = (cronExpression: string) => ({
   libraryTaskId: null,
   templateId: null,
   category: "GENERAL",
+  subcategory: null,
   name: "Recurring task",
   description: null,
+  additionalNotes: null,
   medication: null,
   observationToolId: null,
   dueAt: new Date("2026-01-01T00:00:00Z"),
@@ -37,6 +73,8 @@ const master = (cronExpression: string) => ({
   reminder: null,
   syncWithCalendar: null,
   attachments: null,
+  assignedGroupId: null,
+  priority: null,
 });
 
 describe("TaskRecurrenceEngine invalid cron logging", () => {
@@ -96,5 +134,112 @@ describe("TaskRecurrenceEngine invalid cron logging", () => {
 
     expect(errorSpy).not.toHaveBeenCalled();
     expect(prismaMock.task.create).toHaveBeenCalled();
+  });
+});
+
+const dailyMaster = (overrides: Partial<ReturnType<typeof master>> = {}) => ({
+  ...master("0 0 * * *"),
+  recurrence: { isMaster: true, type: "DAILY" },
+  ...overrides,
+});
+
+describe("TaskRecurrenceEngine occurrence generation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.task.findFirst.mockResolvedValue(null);
+    prismaMock.task.create.mockResolvedValue({});
+  });
+
+  it("keeps the local due time stable across a DST spring-forward (DAILY)", async () => {
+    prismaMock.task.findMany.mockResolvedValue([
+      dailyMaster({
+        // 09:00 CET (+01:00) the day before Europe's spring-forward.
+        dueAt: new Date("2026-03-28T08:00:00.000Z"),
+        timezone: "Europe/Madrid",
+      }),
+    ]);
+
+    await TaskRecurrenceEngine.run();
+
+    const firstCreate = prismaMock.task.create.mock.calls[0][0];
+    // Still 09:00 local, but now CEST (+02:00) -> 07:00 UTC. Offset-
+    // preserving duration math would instead produce 08:00 UTC (10:00 local).
+    expect(firstCreate.data.dueAt).toEqual(
+      new Date("2026-03-29T07:00:00.000Z"),
+    );
+  });
+
+  it("keeps the local due time stable across a DST spring-forward (WEEKLY)", async () => {
+    prismaMock.task.findMany.mockResolvedValue([
+      dailyMaster({
+        recurrence: { isMaster: true, type: "WEEKLY" },
+        // 09:00 CET, one week before the transition.
+        dueAt: new Date("2026-03-22T08:00:00.000Z"),
+        timezone: "Europe/Madrid",
+      }),
+    ]);
+
+    await TaskRecurrenceEngine.run();
+
+    const firstCreate = prismaMock.task.create.mock.calls[0][0];
+    expect(firstCreate.data.dueAt).toEqual(
+      new Date("2026-03-29T07:00:00.000Z"),
+    );
+  });
+
+  it("clones subcategory, additional notes, priority and group assignment onto each occurrence", async () => {
+    prismaMock.task.findMany.mockResolvedValue([
+      dailyMaster({
+        subcategory: "vaccination",
+        additionalNotes: "give with food",
+        priority: "HIGH",
+        assignedGroupId: "group-1",
+      }),
+    ]);
+
+    await TaskRecurrenceEngine.run();
+
+    const firstCreate = prismaMock.task.create.mock.calls[0][0];
+    expect(firstCreate.data.subcategory).toBe("vaccination");
+    expect(firstCreate.data.additionalNotes).toBe("give with food");
+    expect(firstCreate.data.priority).toBe("HIGH");
+    expect(firstCreate.data.assignedGroupId).toBe("group-1");
+  });
+
+  it("resets the reminder's sent marker on a new occurrence instead of copying the parent's", async () => {
+    prismaMock.task.findMany.mockResolvedValue([
+      dailyMaster({
+        reminder: {
+          enabled: true,
+          offsetMinutes: 30,
+          scheduledNotificationId: "already-sent-token",
+        },
+      }),
+    ]);
+
+    await TaskRecurrenceEngine.run();
+
+    const firstCreate = prismaMock.task.create.mock.calls[0][0];
+    expect(firstCreate.data.reminder).toEqual({
+      enabled: true,
+      offsetMinutes: 30,
+      scheduledNotificationId: undefined,
+    });
+  });
+
+  it("queries masters by recurrence.isMaster, never by the occurrence's own status", async () => {
+    // Regression guard for #3181: the master row IS occurrence #1, so
+    // filtering masters on `status !== CANCELLED` stops the whole series
+    // from generating any further children the moment only that first
+    // occurrence gets cancelled. Series-level stop is expressed via
+    // recurrence.endDate instead (see TaskService.deleteTask ALL/
+    // THIS_AND_FOLLOWING), which getNextOccurrence already honors.
+    prismaMock.task.findMany.mockResolvedValue([]);
+
+    await TaskRecurrenceEngine.run();
+
+    expect(prismaMock.task.findMany).toHaveBeenCalledWith({
+      where: { recurrence: { path: ["isMaster"], equals: true } },
+    });
   });
 });

--- a/apps/backend/test/services/task.reminder.engine.test.ts
+++ b/apps/backend/test/services/task.reminder.engine.test.ts
@@ -1,0 +1,143 @@
+const prismaMock = {
+  task: {
+    findMany: jest.fn(),
+    update: jest.fn(),
+  },
+  patient: {
+    findFirst: jest.fn(),
+  },
+};
+
+jest.mock("src/config/prisma", () => ({
+  __esModule: true,
+  prisma: prismaMock,
+}));
+
+const sendToUserMock = jest.fn();
+jest.mock("src/services/notification.service", () => ({
+  NotificationService: {
+    sendToUser: (...args: unknown[]) => sendToUserMock(...args),
+  },
+}));
+
+jest.mock("src/utils/notificationTemplates", () => ({
+  NotificationTemplates: {
+    Task: {
+      TASK_DUE_REMINDER: (
+        companionName: string,
+        taskName: string,
+        when: string,
+      ) => ({
+        companionName,
+        taskName,
+        when,
+      }),
+    },
+  },
+}));
+
+import { TaskReminderEngine } from "src/services/task.reminder.engine";
+
+const dueTask = (overrides: Record<string, unknown> = {}) => ({
+  id: "task-1",
+  name: "Give medication",
+  assignedTo: "user-1",
+  patientId: "patient-1",
+  status: "PENDING",
+  timezone: "UTC",
+  dueAt: new Date("2026-01-01T12:00:00.000Z"),
+  reminder: { enabled: true, offsetMinutes: 0 },
+  ...overrides,
+});
+
+describe("TaskReminderEngine", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    prismaMock.patient.findFirst.mockResolvedValue({ name: "Rex" });
+    prismaMock.task.update.mockResolvedValue({});
+    sendToUserMock.mockResolvedValue([{ token: "notif-token" }]);
+  });
+
+  it("sends a zero-offset reminder on the first tick strictly after the due time", async () => {
+    // Regression for #3183: a `dueAt >= now` query upper bound excluded the
+    // task the instant its due time passed, so the tick just before due
+    // found it "too early" and the tick just after found it already
+    // filtered out - no tick ever delivered a zero-offset reminder.
+    jest.useFakeTimers({ now: new Date("2026-01-01T12:00:01.000Z") });
+    try {
+      prismaMock.task.findMany.mockResolvedValue([dueTask()]);
+
+      await TaskReminderEngine.run();
+
+      expect(sendToUserMock).toHaveBeenCalledTimes(1);
+      expect(sendToUserMock).toHaveBeenCalledWith(
+        "user-1",
+        expect.objectContaining({ taskName: "Give medication" }),
+      );
+      expect(prismaMock.task.update).toHaveBeenCalledWith({
+        where: { id: "task-1" },
+        data: {
+          reminder: expect.objectContaining({
+            scheduledNotificationId: "notif-token",
+          }),
+        },
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("still skips a task whose reminder time has not arrived yet", async () => {
+    jest.useFakeTimers({ now: new Date("2026-01-01T11:59:59.000Z") });
+    try {
+      prismaMock.task.findMany.mockResolvedValue([dueTask()]);
+
+      await TaskReminderEngine.run();
+
+      expect(sendToUserMock).not.toHaveBeenCalled();
+      expect(prismaMock.task.update).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("does not resend once scheduledNotificationId is already set", async () => {
+    jest.useFakeTimers({ now: new Date("2026-01-01T12:00:01.000Z") });
+    try {
+      prismaMock.task.findMany.mockResolvedValue([
+        dueTask({
+          reminder: {
+            enabled: true,
+            offsetMinutes: 0,
+            scheduledNotificationId: "already-sent",
+          },
+        }),
+      ]);
+
+      await TaskReminderEngine.run();
+
+      expect(sendToUserMock).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("bounds the scan query with a lookback window rather than an upper bound of now", async () => {
+    const fixedNow = new Date("2026-01-05T00:00:00.000Z");
+    jest.useFakeTimers({ now: fixedNow });
+    try {
+      prismaMock.task.findMany.mockResolvedValue([]);
+
+      await TaskReminderEngine.run();
+
+      expect(prismaMock.task.findMany).toHaveBeenCalledWith({
+        where: {
+          status: { in: ["PENDING", "IN_PROGRESS"] },
+          dueAt: { gte: new Date("2026-01-04T00:00:00.000Z") },
+        },
+      });
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/apps/backend/test/services/task.schedule.engine.test.ts
+++ b/apps/backend/test/services/task.schedule.engine.test.ts
@@ -312,6 +312,61 @@ describe("TaskScheduleEngine", () => {
     errorSpy.mockRestore();
   });
 
+  it("does not recreate a seed whose task id already persisted from a prior partial retry", async () => {
+    // Regression for #3182: a first activation attempt created "First" and
+    // then failed persisting "Second" mid-loop. If generatedTaskIds is only
+    // ever written once, at the end, that failure leaves it empty and a
+    // retry recreates "First" again - two "First" rows, one orphaned from
+    // the schedule. Persisting after each seed lets the retry resume from
+    // the first seed that has no id yet.
+    const firstSeed = {
+      source: "ORG_TEMPLATE",
+      organisationId: "org-1",
+      createdBy: "creator-1",
+      assignedTo: "employee-1",
+      audience: "EMPLOYEE_TASK",
+      category: "Care",
+      name: "First",
+      dueAt: "2026-01-01T08:00:00.000Z",
+    };
+    const secondSeed = {
+      ...firstSeed,
+      name: "Second",
+      dueAt: "2026-01-01T09:00:00.000Z",
+    };
+
+    mockedPrisma.taskSchedule.findMany.mockResolvedValueOnce([
+      {
+        id: "schedule-retry",
+        templateKind: "CARE_PATHWAY",
+        status: "ACTIVE",
+        // "First" already succeeded and was persisted on the prior attempt.
+        generatedTaskIds: ["first-task-id"],
+        materializedSeeds: [firstSeed, secondSeed],
+      },
+    ]);
+    mockedTaskService.createFromWorkflowSeed.mockResolvedValueOnce({
+      id: "second-task-id",
+    });
+    mockedPrisma.taskSchedule.update.mockResolvedValue({});
+
+    await TaskScheduleEngine.run();
+
+    expect(mockedTaskService.createFromWorkflowSeed).toHaveBeenCalledTimes(1);
+    expect(mockedTaskService.createFromWorkflowSeed).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "Second" }),
+      expect.objectContaining({ notify: false }),
+    );
+    expect(mockedPrisma.taskSchedule.update).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        where: { id: "schedule-retry" },
+        data: expect.objectContaining({
+          generatedTaskIds: ["first-task-id", "second-task-id"],
+        }),
+      }),
+    );
+  });
+
   it("skips schedules that already have generated task ids", async () => {
     mockedPrisma.taskSchedule.findMany.mockResolvedValueOnce([
       {

--- a/apps/backend/test/services/task.service.test.ts
+++ b/apps/backend/test/services/task.service.test.ts
@@ -2632,36 +2632,93 @@ describe("TaskService", () => {
       expect(mockedPrisma.$transaction).not.toHaveBeenCalled();
     });
 
-    it("cancels every occurrence for scope=ALL without touching the master recurrence", async () => {
+    it("cancels every occurrence for scope=ALL and ends the master's recurrence", async () => {
+      // The recurrence engine no longer infers "series stopped" from the
+      // master row's own occurrence status (cancelling only occurrence #1
+      // must not stop the series - see task.recurrence.engine.ts), so an
+      // ALL-scope cancel has to end the series explicitly via
+      // recurrence.endDate, the same mechanism THIS_AND_FOLLOWING uses.
+      const fixedNow = new Date("2026-01-10T00:00:00.000Z");
+      jest.useFakeTimers({ now: fixedNow });
+      try {
+        mockedPrisma.task.findFirst.mockResolvedValueOnce(
+          ownedTask({
+            assignedTo: "user-1",
+            recurrence: { type: "DAILY", isMaster: true },
+          }) as never,
+        );
+        mockedPrisma.task.findMany.mockResolvedValueOnce([
+          { id: "task-1", dueAt, createdBy: "user-1", assignedTo: "user-1" },
+          {
+            id: "task-2",
+            dueAt: new Date("2026-01-02T12:00:00.000Z"),
+            createdBy: "user-1",
+            assignedTo: "user-1",
+          },
+        ] as never);
+        const txUpdateMany = jest.fn().mockResolvedValue({ count: 2 });
+        const txUpdate = jest.fn().mockResolvedValue({});
+        const txFindUnique = jest.fn().mockResolvedValue({
+          id: "task-1",
+          recurrence: { type: "DAILY", isMaster: true },
+        });
+        mockedPrisma.$transaction.mockImplementationOnce(
+          async (cb: (tx: unknown) => Promise<unknown>) =>
+            cb({
+              task: {
+                updateMany: txUpdateMany,
+                update: txUpdate,
+                findUnique: txFindUnique,
+              },
+            }),
+        );
+
+        await TaskService.deleteTask("task-1", "user-1", "ALL", "org-1");
+
+        expect(txUpdateMany).toHaveBeenCalledWith({
+          where: { id: { in: ["task-1", "task-2"] }, organisationId: "org-1" },
+          data: { status: "CANCELLED" },
+        });
+        expect(txFindUnique).toHaveBeenCalledWith({
+          where: { id: "task-1" },
+        });
+        expect(txUpdate).toHaveBeenCalledWith({
+          where: { id: "task-1" },
+          data: {
+            recurrence: {
+              type: "DAILY",
+              isMaster: true,
+              masterTaskId: undefined,
+              cronExpression: undefined,
+              endDate: fixedNow,
+            },
+          },
+        });
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it("cancelling only the first occurrence (scope=THIS) on a master row does not touch its recurrence", async () => {
+      // Regression for #3181: the master row IS occurrence #1, so a plain
+      // "THIS" cancel on it must only flip that row's own status and must
+      // never write recurrence.endDate - otherwise the series stops
+      // generating any further occurrences.
       mockedPrisma.task.findFirst.mockResolvedValueOnce(
         ownedTask({
           assignedTo: "user-1",
           recurrence: { type: "DAILY", isMaster: true },
         }) as never,
       );
-      mockedPrisma.task.findMany.mockResolvedValueOnce([
-        { id: "task-1", dueAt, createdBy: "user-1", assignedTo: "user-1" },
-        {
-          id: "task-2",
-          dueAt: new Date("2026-01-02T12:00:00.000Z"),
-          createdBy: "user-1",
-          assignedTo: "user-1",
-        },
-      ] as never);
-      const txUpdateMany = jest.fn().mockResolvedValue({ count: 2 });
-      const txUpdate = jest.fn();
-      mockedPrisma.$transaction.mockImplementationOnce(
-        async (cb: (tx: unknown) => Promise<unknown>) =>
-          cb({ task: { updateMany: txUpdateMany, update: txUpdate } }),
-      );
+      mockedPrisma.task.update.mockResolvedValueOnce({} as never);
 
-      await TaskService.deleteTask("task-1", "user-1", "ALL", "org-1");
+      await TaskService.deleteTask("task-1", "user-1");
 
-      expect(txUpdateMany).toHaveBeenCalledWith({
-        where: { id: { in: ["task-1", "task-2"] }, organisationId: "org-1" },
+      expect(mockedPrisma.task.update).toHaveBeenCalledWith({
+        where: { id: "task-1" },
         data: { status: "CANCELLED" },
       });
-      expect(txUpdate).not.toHaveBeenCalled();
+      expect(mockedPrisma.$transaction).not.toHaveBeenCalled();
     });
 
     it("caps the master recurrence and cancels only future rows for THIS_AND_FOLLOWING", async () => {


### PR DESCRIPTION
## Summary
Batches five related backend bugs in recurring-task generation and reminder delivery:

- **#3179** - a recurring task's due time drifted an hour across a DST transition because next-occurrence math preserved the previous instant's UTC offset instead of recomputing local wall-clock time.
- **#3180** - generated occurrences dropped subcategory, additional notes, priority and group assignment, and copied the parent's reminder `scheduledNotificationId` verbatim, so the reminder worker treated the new occurrence as already sent.
- **#3181** - the recurrence engine filtered "masters" by their own occurrence status; since the master row IS occurrence #1, cancelling only that occurrence (scope `THIS`) stopped the whole series from generating further children. Series-level stop is now expressed via `recurrence.endDate` on all three cancel scopes (`THIS_AND_FOLLOWING` already did this; `ALL` now does too).
- **#3182** - a deferred workflow schedule's `generatedTaskIds` was only persisted once, after every seed finished; a mid-loop failure left it empty, so a retry recreated already-succeeded tasks. It's now persisted incrementally per seed.
- **#3183** - the reminder worker's query used `dueAt >= now` as an upper bound, so a zero-offset reminder fell through the gap between "too early" (previous tick) and "already past due" (next tick) and never sent. The query now uses a lookback grace window instead.

## Test plan
- [x] `npx jest` (apps/backend): 500 suites / 11,850 tests passed
- [x] `npx eslint .` (apps/backend): 0 errors
- [x] `npx tsc --noEmit` (apps/backend): 0 errors
- [x] Added/updated targeted tests for all 5 fixes; mutation-checked each by reverting the fix and confirming the corresponding test fails, then restoring
- [x] Pre-push hook (monorepo lint + type-check via turbo): passed