### PR TITLE
test(frontend): repair stale Storybook interactions

### DIFF
--- a/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Text/TextRenderer.stories.tsx
+++ b/apps/frontend/src/app/features/forms/pages/Forms/Sections/AddForm/components/Text/TextRenderer.stories.tsx
@@ -8,8 +8,8 @@ import TextRenderer from './TextRenderer';
 
 type TextareaField = FormField & { type: 'textarea' };
 
-/** `placeholder` is authored in the builder and, as the stories below show, never
-    reaches the runtime control - FormDesc has no placeholder prop at all. */
+/** `placeholder` is authored in the builder and never reaches the runtime control;
+    FormDesc falls back to the field label instead. */
 const HISTORY: TextareaField = {
   id: 'history',
   type: 'textarea',
@@ -73,10 +73,10 @@ const meta = {
           'answers scroll inside the box rather than pushing the rest of the form down the page, ' +
           'which is the behaviour that matters and the one asserted.\n\n' +
           'Two things it does NOT do, both asserted below because both are invisible until ' +
-          'someone relies on them. The authored `placeholder` is dropped - FormDesc accepts no ' +
-          'placeholder prop, so an empty field shows an empty box and nothing else. And FormDesc ' +
-          'hardcodes `required` on the textarea, so a field the schema marks optional is still a ' +
-          'required control in the DOM.',
+          'someone relies on them. The authored `placeholder` is dropped - TextRenderer passes ' +
+          'none, so FormDesc falls back to the field label. And FormDesc defaults `required` on ' +
+          'the textarea, so a field the schema marks optional is still a required control in ' +
+          'the DOM.',
       },
     },
   },
@@ -104,9 +104,9 @@ export const Default: Story = {
     await expect(textarea).toHaveAttribute('name', 'history');
     await expect(textarea).toHaveValue('Reduced appetite for four days.');
 
-    // The builder lets an author write a placeholder for this field; FormDesc has
-    // no placeholder prop, so it never arrives. An empty answer shows a bare box.
-    await expect(textarea).not.toHaveAttribute('placeholder');
+    // The builder lets an author write a placeholder for this field, but TextRenderer
+    // drops it. FormDesc receives no explicit placeholder and falls back to the label.
+    await expect(textarea).toHaveAttribute('placeholder', 'History');
 
     // It emits the string, not the change event. A renderer that forwarded `e`
     // would still "work" until the caller tried to store the value.
@@ -160,13 +160,13 @@ export const MissingLabel: Story = {
   play: async ({ canvasElement }) => {
     const textarea = within(canvasElement).getByRole('textbox');
 
-    /* `field.label || ''` is passed straight through, and FormDesc renders it in
-       both places at once: an empty <label> and `aria-label=""`. An empty
-       aria-label is ignored, the empty label element contributes nothing, so the
-       control ends up with no accessible name and a screen reader announces a
-       bare text area. FormRenderer covers for this by inventing a label from the
-       field id before it gets here - mounted directly, nothing does. */
-    await expect(textarea).toHaveAttribute('aria-label', '');
+    /* `field.label || ''` is passed straight through. FormDesc renders an empty
+       <label> and falls back to an empty placeholder, while Textarea adds no
+       `aria-label`. The empty label contributes nothing, so the control ends up
+       with no accessible name. FormRenderer covers for this by inventing a label
+       from the field id before it gets here - mounted directly, nothing does. */
+    await expect(textarea).not.toHaveAttribute('aria-label');
+    await expect(textarea).toHaveAttribute('placeholder', '');
     const label = canvasElement.querySelector(`label[for="${CSS.escape(textarea.id)}"]`);
     await expect(label).not.toBeNull();
     await expect(label?.textContent).toBe('');

--- a/apps/frontend/src/app/features/tasks/components/TaskFormFields.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/components/TaskFormFields.stories.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, within } from 'storybook/test';
+import { expect, fn, userEvent, within } from 'storybook/test';
 
 import type { Option } from '@/app/features/companions/types/companion';
 import type { Task } from '@/app/features/tasks/types/task';
@@ -134,11 +134,8 @@ const meta = {
           'each branch - last in the two stacks, but *above* Instructions in the chips layout. ' +
           '**The template picker disappears** when `hideTemplatePicker` is set or ' +
           '`templateOptions` is empty, and those two paths are indistinguishable in the output.\n\n' +
-          'Errors are reported inconsistently by the underlying inputs, which is the one ' +
-          'accessibility fact worth knowing here: the task name, due date and time errors are ' +
-          '`role="alert"`, while the category and assignee errors come from `LabelDropdown` and ' +
-          'are announced to nobody. The same `dueAt` error is also passed to two fields, so it ' +
-          'renders - and is announced - twice.',
+          'Every validation message is announced with `role="alert"`. The shared `dueAt` error ' +
+          'is passed to both the date and time fields, so it renders - and is announced - twice.',
       },
     },
   },
@@ -261,7 +258,7 @@ export const DialogTwoColumn: Story = {
 };
 
 export const NewTaskChips: Story = {
-  name: 'Two column with assignee chips - the New task dialog',
+  name: 'Two column with grouped assignee picker - the New task dialog',
   args: {
     twoColumn: true,
     assigneeChips: true,
@@ -294,16 +291,17 @@ export const NewTaskChips: Story = {
     await expect(canvas.queryByText('Assigned to')).not.toBeInTheDocument();
     await expect(canvas.getByText('Assign to')).toBeInTheDocument();
 
-    /* Exactly one chip is pressed, and it is the team chip for the task's current
-       assignee - `audience` decides which list the selection is read against, so a
-       parent whose id happened to match would NOT light up here. Matched on the
-       pressed state and the text rather than the accessible name, because the
-       monogram avatar is not `aria-hidden` and folds its initials into the name. */
-    const chipRow = fieldRoot(canvasElement).children[3] as HTMLElement;
-    const pressed = within(chipRow).getAllByRole('button', { pressed: true });
-    await expect(pressed).toHaveLength(1);
-    await expect(pressed[0]).toHaveTextContent('Dr. Ravi Patel');
-    await expect(within(chipRow).getAllByRole('button')).toHaveLength(3);
+    /* The compact chip row was replaced by one searchable picker. The trigger resolves
+       the current staff assignee, while the portalled list keeps all three grouped
+       choices and marks that assignee as selected. */
+    const trigger = canvas.getByRole('button', { name: 'Assign to: Dr. Ravi Patel' });
+    await userEvent.click(trigger);
+    const listbox = await within(document.body).findByRole('listbox');
+    const options = within(listbox).getAllByRole('option');
+    await expect(options).toHaveLength(3);
+    const selected = options.filter((option) => option.getAttribute('aria-selected') === 'true');
+    await expect(selected).toHaveLength(1);
+    await expect(selected[0]).toHaveTextContent('Dr. Ravi Patel');
 
     /* Due / Time / Repeat share a three-track row and Priority / Reminder a
        two-track one - the demotion of the secondary controls below the core fields
@@ -386,17 +384,14 @@ export const ValidationErrors: Story = {
        a duplication bug if you meet it in a screenshot. */
     await expect(canvas.getAllByText('Due date and time are required')).toHaveLength(2);
 
-    /* Three alerts, not five. The task name, due date and time errors are
-       `role="alert"`; the category and assignee errors come from `LabelDropdown`,
-       which renders them as plain text - visible, red, and announced to nobody.
-       Asserted as a count so that fixing the dropdown flips this deliberately
-       rather than passing quietly. */
+    /* Five alerts: task name, category, assignee, due date and due time. The due
+       message appears twice because both controls receive the same field error. */
     const alerts = canvas.getAllByRole('alert');
-    await expect(alerts).toHaveLength(3);
-    await expect(canvas.getByText('Category is required').closest('[role="alert"]')).toBeNull();
+    await expect(alerts).toHaveLength(5);
+    await expect(canvas.getByText('Category is required').closest('[role="alert"]')).not.toBeNull();
     await expect(
       canvas.getByText('Please select a companion or staff').closest('[role="alert"]')
-    ).toBeNull();
+    ).not.toBeNull();
     await expect(canvas.getByText('Name is required').closest('[role="alert"]')).not.toBeNull();
 
     // The empty task name is a real empty input, not a placeholder-shaped value.

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/ChangeStatus.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/Sections/ChangeStatus.stories.tsx
@@ -291,7 +291,7 @@ export const ChoosingAStatus: Story = {
     const dialog = await openDialog(canvasElement);
     const panel = await openStatusMenu(dialog, 'Pending');
 
-    await userEvent.click(within(panel).getByRole('button', { name: 'Completed' }));
+    await userEvent.click(within(panel).getByRole('option', { name: 'Completed' }));
 
     // The selection moves the trigger label and closes the panel. Both matter:
     // `LabelDropdown` keeps its own `internalSelected`, so a controlled parent
@@ -327,7 +327,7 @@ export const CancelLeavesTheTask: Story = {
     // Move the selection first, so Cancel has something to abandon. Cancelling an
     // untouched dialog would close either way and prove nothing about discarding.
     const panel = await openStatusMenu(dialog, 'Pending');
-    await userEvent.click(within(panel).getByRole('button', { name: 'Cancelled' }));
+    await userEvent.click(within(panel).getByRole('option', { name: 'Cancelled' }));
     await expect(
       within(dialog).getByRole('button', { name: 'Task status: Cancelled' })
     ).toBeInTheDocument();

--- a/apps/frontend/src/app/features/tasks/pages/Tasks/index.stories.tsx
+++ b/apps/frontend/src/app/features/tasks/pages/Tasks/index.stories.tsx
@@ -498,7 +498,7 @@ export const PermissionDenied: Story = {
     // gated body underneath is swapped for the denied card.
     await expect(await canvas.findByRole('heading', { level: 1, name: 'Tasks (4)' })).toBeVisible();
     await expect(canvas.getByRole('button', { name: 'List' })).toBeVisible();
-    await expect(await canvas.findByText(/You.t have access to Tasks/)).toBeVisible();
+    await expect(await canvas.findByText("You don't have access to Tasks")).toBeVisible();
     await expect(
       canvas.getByText(/Your role \(Owner\) can.t view tasks and assignments\./)
     ).toBeVisible();


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for.
- [x] All existing tests and lints pass.

## What is the current behavior?

Four existing Storybook files contain interaction assertions or documentation that no longer match the rendered components. The stale expectations fail when the #2281 test-runner work executes their play functions.

## What is the new behavior?

- Aligns `TextRenderer` placeholder and missing-label assertions with the rendered textarea contract.
- Exercises the current grouped assignee listbox and all five validation alerts in `TaskFormFields`.
- Selects task statuses through their current `option` role and matches the permission-denied copy exactly.

This changes Storybook tests and documentation only; rendered production UI is unchanged.

## Validation

- `pnpm --filter frontend test` — 1,067 suites and 13,577 tests passed.
- `pnpm --filter frontend run storybook:build` — completed successfully on the tag-free candidate.
- `pnpm lint` and `pnpm type-check` — completed successfully in the pre-push hook.
- Seven affected play functions — passed in Chromium with zero console errors after each repaired assertion was independently mutated and observed failing.
- Aikido — scanned all four changed files with zero findings.

## Related Issue(s)

Refs #2281
