### PR TITLE
fix(frontend): preserve calendar dates and slot labels

### DIFF
--- a/apps/frontend/src/app/__tests__/components/Calendar/Task/TaskSlot.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/Task/TaskSlot.test.tsx
@@ -6,6 +6,7 @@ import { axe, toHaveNoViolations } from 'jest-axe';
 import TaskSlot from '@/app/features/appointments/components/Calendar/Task/TaskSlot';
 import { Task } from '@/app/features/tasks/types/task';
 import { calcNearestAvailableMinute } from '@/app/features/appointments/components/Calendar/calendarDrop';
+import { getPreferredTimeZone, setPreferredTimeZone } from '@/app/lib/timezone';
 
 jest.mock('@/app/hooks/useTeam', () => ({
   useTeamForPrimaryOrg: jest.fn(),
@@ -25,11 +26,43 @@ expect.extend(toHaveNoViolations);
 
 describe('TaskSlot', () => {
   const handleViewTask = jest.fn();
+  const originalTimeZone = getPreferredTimeZone();
 
   beforeEach(() => {
     jest.clearAllMocks();
     (useTeamForPrimaryOrg as jest.Mock).mockReturnValue([{ _id: 'user-1', name: 'Alex' }]);
     (calcNearestAvailableMinute as jest.Mock).mockImplementation((minute: number) => minute);
+  });
+
+  afterEach(() => {
+    setPreferredTimeZone(originalTimeZone);
+  });
+
+  it('announces the row time without inheriting the date cursor clock', () => {
+    setPreferredTimeZone('America/Los_Angeles');
+    const cursorAt1527 = new Date('2026-03-16T22:27:00.000Z');
+
+    render(
+      <TaskSlot
+        slotEvents={[]}
+        handleViewTask={handleViewTask}
+        height={180}
+        hour={0}
+        dropDate={cursorAt1527}
+        onCreateTaskAt={jest.fn()}
+      />
+    );
+
+    expect(
+      screen.getByRole('region', {
+        name: 'Tasks slot for Monday, March 16 at 12:00 AM',
+      })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Create task on Monday, March 16 at 12:00 AM',
+      })
+    ).toBeInTheDocument();
   });
 
   it('renders tasks with member names and triggers view handler', () => {

--- a/apps/frontend/src/app/__tests__/components/Calendar/common/Slot.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/Calendar/common/Slot.test.tsx
@@ -9,8 +9,45 @@ import {
   acceptAppointment,
   rejectAppointment,
 } from '@/app/features/appointments/services/appointmentService';
+import { getPreferredTimeZone, setPreferredTimeZone } from '@/app/lib/timezone';
 
 jest.useFakeTimers();
+const originalTimeZone = getPreferredTimeZone();
+
+afterEach(() => {
+  setPreferredTimeZone(originalTimeZone);
+});
+
+it('announces the appointment row time without inheriting the date cursor clock', () => {
+  setPreferredTimeZone('America/Los_Angeles');
+  const cursorAt1527 = new Date('2026-03-16T22:27:00.000Z');
+
+  render(
+    <Slot
+      slotEvents={[]}
+      height={120}
+      handleViewAppointment={jest.fn()}
+      handleRescheduleAppointment={jest.fn()}
+      dayIndex={0}
+      length={0}
+      canEditAppointments
+      dropDate={cursorAt1527}
+      dropHour={9}
+      onCreateAppointmentAt={jest.fn()}
+    />
+  );
+
+  expect(
+    screen.getByRole('region', {
+      name: 'Appointments slot for Monday, March 16 at 9:00 AM',
+    })
+  ).toBeInTheDocument();
+  expect(
+    screen.getByRole('button', {
+      name: 'Create appointment on Monday, March 16 at 9:00 AM',
+    })
+  ).toBeInTheDocument();
+});
 
 jest.mock('next/image', () => ({
   __esModule: true,

--- a/apps/frontend/src/app/__tests__/components/InventoryInfo/helpers.test.ts
+++ b/apps/frontend/src/app/__tests__/components/InventoryInfo/helpers.test.ts
@@ -14,6 +14,9 @@ import {
 } from '@/app/features/inventory/components/inventoryInfoHelpers';
 
 jest.mock('@/app/features/inventory/pages/Inventory/utils', () => ({
+  parseInventoryCalendarDateParts: jest.requireActual(
+    '@/app/features/inventory/pages/Inventory/utils'
+  ).parseInventoryCalendarDateParts,
   formatDisplayDate: jest.fn((value) => (value ? `Formatted ${value}` : '')),
   toStringSafe: jest.fn((value) => (value === null || value === undefined ? '' : String(value))),
   formatCurrencyValue: jest.fn(),
@@ -56,13 +59,15 @@ describe('InventoryInfo helpers', () => {
   });
 
   it('parses ISO, dd/mm/yyyy, and invalid dates correctly', () => {
-    expect(parseDate('2026-07-06')?.toISOString()).toContain('2026-07-06');
-    expect(parseDate('06/07/2026')?.toISOString()).toContain('2026-07-06');
+    expect(parseDate('2026-07-06')).toEqual(new Date(2026, 6, 6));
+    expect(parseDate('06/07/2026')).toEqual(new Date(2026, 6, 6));
+    expect(parseDate('2026-03-01T00:00:00.000Z')).toEqual(new Date(2026, 2, 1));
+    expect(parseDate('2026-02-31')).toBeNull();
     expect(parseDate('not-a-date')).toBeNull();
   });
 
   it('formats dates as yyyy-mm-dd', () => {
-    expect(formatDate(new Date('2026-07-06T00:00:00.000Z'))).toBe('2026-07-06');
+    expect(formatDate(new Date(2026, 6, 6))).toBe('2026-07-06');
   });
 
   it('normalizes options and resolves labels with fallback', () => {

--- a/apps/frontend/src/app/__tests__/components/InventoryInfo/index.test.tsx
+++ b/apps/frontend/src/app/__tests__/components/InventoryInfo/index.test.tsx
@@ -2,12 +2,16 @@ import React from 'react';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import InventoryInfo from '@/app/features/inventory/components/InventoryInfo';
 import { BusinessType } from '@/app/features/organization/types/org';
+import type { InventoryItem } from '@/app/features/inventory/pages/Inventory/types';
 
 // ----------------------------------------------------------------------------
 // 1. Mocks & Setup
 // ----------------------------------------------------------------------------
 
 jest.mock('@/app/features/inventory/pages/Inventory/utils', () => ({
+  parseInventoryCalendarDateParts: jest.requireActual(
+    '@/app/features/inventory/pages/Inventory/utils'
+  ).parseInventoryCalendarDateParts,
   formatDisplayDate: jest.fn((val) => (val ? `Formatted ${val}` : '')),
   toStringSafe: jest.fn((val) => (val === null || val === undefined ? '' : String(val))),
   formatCurrencyValue: jest.fn((val, currency) =>
@@ -120,24 +124,31 @@ const getAction = () => screen.queryByTestId('danger-btn') ?? screen.getByTestId
 
 jest.mock('@/app/ui/inputs/Datepicker', () => ({
   __esModule: true,
-  default: ({ currentDate, setCurrentDate, placeholder }: any) => (
-    <>
-      <input
-        data-testid={`datepicker-${placeholder}`}
-        value={currentDate ? currentDate.toISOString().split('T')[0] : ''}
-        onChange={(e) => {
-          const d = e.target.value ? new Date(e.target.value) : null;
-          setCurrentDate(d);
-        }}
-      />
-      {/* Drives the updater-function form of setCurrentDate. */}
-      <button
-        type="button"
-        data-testid={`datepicker-updater-${placeholder}`}
-        onClick={() => setCurrentDate((prev: Date | null) => prev ?? new Date(2030, 2, 4))}
-      />
-    </>
-  ),
+  default: ({ currentDate, setCurrentDate, placeholder }: any) => {
+    const localDate = currentDate
+      ? `${currentDate.getFullYear()}-${String(currentDate.getMonth() + 1).padStart(2, '0')}-${String(
+          currentDate.getDate()
+        ).padStart(2, '0')}`
+      : '';
+    return (
+      <>
+        <input
+          data-testid={`datepicker-${placeholder}`}
+          value={localDate}
+          onChange={(e) => {
+            const d = e.target.value ? new Date(e.target.value) : null;
+            setCurrentDate(d);
+          }}
+        />
+        {/* Drives the updater-function form of setCurrentDate. */}
+        <button
+          type="button"
+          data-testid={`datepicker-updater-${placeholder}`}
+          onClick={() => setCurrentDate((prev: Date | null) => prev ?? new Date(2030, 2, 4))}
+        />
+      </>
+    );
+  },
 }));
 
 jest.mock('@/app/ui/inputs/Dropdown/LabelDropdown', () => ({
@@ -443,6 +454,34 @@ describe('InventoryInfo Component', () => {
     await act(async () => {
       fireEvent.click(getAction());
     });
+  });
+
+  it('opens a midnight UTC expiry on the same picker day and preserves it on unrelated edits', async () => {
+    const itemWithUtcExpiry = {
+      ...defaultProps.activeInventory,
+      batches: [
+        {
+          ...defaultProps.activeInventory.batches![0],
+          expiryDate: '2026-03-01T00:00:00.000Z',
+        },
+      ],
+    } as InventoryItem;
+    render(<InventoryInfo {...defaultProps} activeInventory={itemWithUtcExpiry} />);
+    fireEvent.click(screen.getByTestId('tab-batch'));
+    fireEvent.click(screen.getByTestId('accordion-edit-btn'));
+
+    expect(screen.getAllByTestId('datepicker-Exp Date')[0]).toHaveValue('2026-03-01');
+    fireEvent.change(screen.getAllByTestId('input-barcode')[0], {
+      target: { value: 'UNCHANGED-DATE' },
+    });
+    await act(async () => {
+      fireEvent.click(getAction());
+    });
+
+    expect(mockOnUpdateBatch).toHaveBeenCalledWith(
+      'item-1',
+      expect.arrayContaining([expect.objectContaining({ expiryDate: '2026-03-01T00:00:00.000Z' })])
+    );
   });
 
   it('saves batch-section barcode and expiry warning per batch, without mirroring to item attributes', async () => {

--- a/apps/frontend/src/app/__tests__/pages/Inventory/InventoryPhoneCatalog.test.tsx
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/InventoryPhoneCatalog.test.tsx
@@ -85,11 +85,13 @@ const lowItem = makeItem({
 describe('InventoryPhoneCatalog helpers', () => {
   it('formatExpiryShort handles ISO, dd/mm/yyyy, empty and invalid dates', () => {
     expect(formatExpiryShort('2028-01-15')).toBe('01/2028');
+    expect(formatExpiryShort('2026-03-01T00:00:00.000Z')).toBe('03/2026');
     expect(formatExpiryShort('15/06/2027')).toBe('06/2027');
     expect(formatExpiryShort('')).toBe('');
     expect(formatExpiryShort(undefined)).toBe('');
     expect(formatExpiryShort('aa/bb/cccc')).toBe('');
     expect(formatExpiryShort('not-a-date')).toBe('');
+    expect(formatExpiryShort('2026-02-31')).toBe('');
   });
 
   it('getPhoneUnitAbbrev infers box vs unit from the item name', () => {

--- a/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
+++ b/apps/frontend/src/app/__tests__/pages/Inventory/utils.test.ts
@@ -86,6 +86,10 @@ describe('Inventory Utils', () => {
       expect(formatDisplayDate(dateStr)).toBe('Oct 5, 2023');
     });
 
+    it('keeps a midnight UTC calendar date on the same displayed day', () => {
+      expect(formatDisplayDate('2026-03-01T00:00:00.000Z')).toBe('Mar 1, 2026');
+    });
+
     it('formats Slash separated dates (dd/mm/yyyy) correctly', () => {
       const dateStr = '05/10/2023'; // 5th Oct
       expect(formatDisplayDate(dateStr)).toBe('Oct 5, 2023');
@@ -642,6 +646,25 @@ describe('Inventory Utils', () => {
         };
         const payload = buildBatchPayload(batch);
         expect(payload?.expiryDate).toBe('2026-01-01T05:30:00.000Z');
+      });
+
+      it('rejects impossible calendar dates instead of rolling them forward', () => {
+        const batch = {
+          ...mockInventoryItem.batches![1],
+          manufactureDate: '2025-02-29',
+          expiryDate: '31/02/2026',
+          nextRefillDate: '2026-13-01',
+        };
+        const payload = buildBatchPayload(batch);
+
+        expect(payload).not.toHaveProperty('manufactureDate');
+        expect(payload).not.toHaveProperty('expiryDate');
+        expect(payload).not.toHaveProperty('minShelfLifeAlertDate');
+      });
+
+      it('accepts leap day as a calendar date', () => {
+        const batch = { ...mockInventoryItem.batches![1], expiryDate: '2028-02-29' };
+        expect(buildBatchPayload(batch)?.expiryDate).toBe('2028-02-29T00:00:00.000Z');
       });
 
       it('preserves per-batch expiry warning and barcode fields', () => {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/Task/TaskSlot.tsx
@@ -9,7 +9,11 @@ import {
   autoScrollCalendarHorizontally,
   autoScrollCalendarVertically,
 } from '@/app/features/appointments/components/Calendar/helpers';
-import { formatDateInPreferredTimeZone, getDatePartsInPreferredTimeZone } from '@/app/lib/timezone';
+import {
+  buildDateInPreferredTimeZone,
+  formatDateInPreferredTimeZone,
+  getDatePartsInPreferredTimeZone,
+} from '@/app/lib/timezone';
 import TaskSlotGridLines from '@/app/features/appointments/components/Calendar/Task/TaskSlotGridLines';
 import TaskDropOverlays from '@/app/features/appointments/components/Calendar/Task/TaskDropOverlays';
 import TaskMarker from '@/app/features/appointments/components/Calendar/Task/TaskMarker';
@@ -26,7 +30,7 @@ const buildTaskSlotLabels = (dropDate: Date, hour: number) => {
     day: 'numeric',
   });
   const timeLabel = formatDateInPreferredTimeZone(
-    new Date(dropDate.getTime() + hour * 60 * 60 * 1000),
+    buildDateInPreferredTimeZone(dropDate, hour * 60),
     { hour: 'numeric', minute: '2-digit' }
   );
   return {

--- a/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
+++ b/apps/frontend/src/app/features/appointments/components/Calendar/common/Slot.tsx
@@ -7,7 +7,7 @@ import {
   autoScrollCalendarVertically,
 } from '@/app/features/appointments/components/Calendar/helpers';
 import { calcNearestAvailableMinute } from '@/app/features/appointments/components/Calendar/calendarDrop';
-import { formatDateInPreferredTimeZone } from '@/app/lib/timezone';
+import { buildDateInPreferredTimeZone, formatDateInPreferredTimeZone } from '@/app/lib/timezone';
 import { CalendarZoomMode } from '@/app/features/appointments/components/Calendar/calendarLayout';
 import { useNotify } from '@/app/hooks/useNotify';
 import { useSlotMarkerInteractions } from '@/app/features/appointments/components/Calendar/common/useSlotMarkerInteractions';
@@ -109,7 +109,7 @@ const buildSlotLabels = (dropDate: Date | undefined, dropHour: number) => {
     day: 'numeric',
   });
   const timeLabel = formatDateInPreferredTimeZone(
-    new Date(dropDate.getTime() + dropHour * 60 * 60 * 1000),
+    buildDateInPreferredTimeZone(dropDate, dropHour * 60),
     { hour: 'numeric', minute: '2-digit' }
   );
   return {

--- a/apps/frontend/src/app/features/inventory/components/InventoryInfo.stories.tsx
+++ b/apps/frontend/src/app/features/inventory/components/InventoryInfo.stories.tsx
@@ -289,3 +289,35 @@ export const PricingSection: Story = {
     },
   },
 };
+
+export const CalendarDateBoundary: Story = {
+  name: 'Batch calendar date at UTC boundary',
+  args: {
+    initialSection: 'batch',
+    activeInventory: {
+      ...ITEM,
+      batch: {
+        ...ITEM.batch,
+        manufactureDate: '2028-02-29T00:00:00.000Z',
+        expiryDate: '2026-03-01T00:00:00.000Z',
+      },
+      batches: [
+        {
+          ...ITEM.batches![0],
+          manufactureDate: '2028-02-29T00:00:00.000Z',
+          expiryDate: '2026-03-01T00:00:00.000Z',
+        },
+      ],
+    },
+  },
+  play: async () => {
+    const body = within(document.body);
+    await userEvent.click(await body.findByRole('button', { name: 'Edit Batch / Lot details' }));
+    await expect(
+      body.getByRole('button', { name: 'Manufacturing date: Feb 29, 2028, toggle calendar' })
+    ).toBeInTheDocument();
+    await expect(
+      body.getByRole('button', { name: 'Expiry date: Mar 1, 2026, toggle calendar' })
+    ).toBeInTheDocument();
+  },
+};

--- a/apps/frontend/src/app/features/inventory/components/inventoryInfoHelpers.ts
+++ b/apps/frontend/src/app/features/inventory/components/inventoryInfoHelpers.ts
@@ -1,5 +1,8 @@
 import { InventoryItem } from '@/app/features/inventory/pages/Inventory/types';
-import { formatDisplayDate } from '@/app/features/inventory/pages/Inventory/utils';
+import {
+  formatDisplayDate,
+  parseInventoryCalendarDateParts,
+} from '@/app/features/inventory/pages/Inventory/utils';
 
 export const validateNumberField = (
   value: unknown,
@@ -62,22 +65,8 @@ export const getStockErrors = (
 };
 
 export const parseDate = (value?: string): Date | null => {
-  if (!value) return null;
-  if (value.includes('/')) {
-    const [dd, mm, yyyy] = value.split('/');
-    const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
-    if (!Number.isNaN(parsed.getTime())) return parsed;
-  }
-
-  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
-  if (isoMatch) {
-    const [, yyyy, mm, dd] = isoMatch;
-    const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
-    if (!Number.isNaN(parsed.getTime())) return parsed;
-  }
-
-  const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
+  const parts = parseInventoryCalendarDateParts(value);
+  return parts ? new Date(parts.year, parts.month - 1, parts.day) : null;
 };
 
 export const formatDate = (date: Date) => {

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/InventoryPhoneCatalog.utils.ts
@@ -4,6 +4,7 @@ import {
   formatCurrencyValue,
   formatPercentValue,
   getMarginPercent,
+  parseInventoryCalendarDateParts,
   toDisplayNumber,
 } from './utils';
 
@@ -17,23 +18,9 @@ export const getPhoneUnitAbbrev = (item: InventoryItem): string => {
 
 /** Expiry as the design's compact `MM/YYYY`, or '' when the date is missing/invalid. */
 export const formatExpiryShort = (value?: string): string => {
-  if (!value) return '';
-  let date: Date | null = null;
-  if (value.includes('/')) {
-    const parts = value.split('/');
-    if (parts.length === 3 && parts[2].length === 4) {
-      const [dd, mm, yyyy] = parts;
-      const parsed = new Date(Number(yyyy), Number(mm) - 1, Number(dd));
-      if (!Number.isNaN(parsed.getTime())) date = parsed;
-    }
-  }
-  if (!date) {
-    const parsed = new Date(value);
-    if (!Number.isNaN(parsed.getTime())) date = parsed;
-  }
-  if (!date) return '';
-  const month = String(date.getMonth() + 1).padStart(2, '0');
-  return `${month}/${date.getFullYear()}`;
+  const parts = parseInventoryCalendarDateParts(value);
+  if (!parts) return '';
+  return `${String(parts.month).padStart(2, '0')}/${parts.year}`;
 };
 
 // Inventory numeric fields arrive as strings that are '' when absent; `Number('')`

--- a/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
+++ b/apps/frontend/src/app/features/inventory/pages/Inventory/utils.ts
@@ -9,7 +9,6 @@ import {
   StockHealthStatus,
   BatchValues,
 } from '@/app/features/inventory/pages/Inventory/types';
-import { formatDisplayDate as formatGlobalDisplayDate } from '@/app/lib/date';
 /* The blank-aware pair lives in lib/validators, beside the other coercions, so
    surfaces outside inventory can use it too. Re-exported here because this
    file's own consumers already import their numeric helpers from it. */
@@ -46,21 +45,48 @@ const cleanObject = (obj: Record<string, unknown>) =>
     return acc;
   }, {});
 
-const parseDateSafe = (value?: string): Date | null => {
+export type InventoryCalendarDateParts = { year: number; month: number; day: number };
+
+export const parseInventoryCalendarDateParts = (
+  value?: string
+): InventoryCalendarDateParts | null => {
   if (!value) return null;
-  if (value.includes('/')) {
-    const [dd, mm, yyyy] = value.split('/');
-    const parsed = new Date(`${yyyy}-${mm}-${dd}`);
-    if (!Number.isNaN(parsed.getTime())) return parsed;
+  const slashMatch = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(value);
+  const isoMatch = /^(\d{4})-(\d{2})-(\d{2})(?:$|T)/.exec(value);
+  let parts: InventoryCalendarDateParts | null = null;
+  if (slashMatch) {
+    parts = {
+      year: Number(slashMatch[3]),
+      month: Number(slashMatch[2]),
+      day: Number(slashMatch[1]),
+    };
+  } else if (isoMatch) {
+    parts = { year: Number(isoMatch[1]), month: Number(isoMatch[2]), day: Number(isoMatch[3]) };
   }
-  const parsed = new Date(value);
-  return Number.isNaN(parsed.getTime()) ? null : parsed;
+  if (!parts) return null;
+  const check = new Date(Date.UTC(parts.year, parts.month - 1, parts.day));
+  const valid =
+    check.getUTCFullYear() === parts.year &&
+    check.getUTCMonth() === parts.month - 1 &&
+    check.getUTCDate() === parts.day;
+  return valid ? parts : null;
+};
+
+const parseDateSafe = (value?: string): Date | null => {
+  const parts = parseInventoryCalendarDateParts(value);
+  return parts ? new Date(Date.UTC(parts.year, parts.month - 1, parts.day)) : null;
 };
 
 export const formatDisplayDate = (value?: string): string => {
   if (!value) return '';
-  const normalizedDate = parseDateSafe(value);
-  return normalizedDate ? formatGlobalDisplayDate(normalizedDate, '') : '';
+  const parts = parseInventoryCalendarDateParts(value);
+  if (!parts) return '';
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+    timeZone: 'UTC',
+  }).format(new Date(Date.UTC(parts.year, parts.month - 1, parts.day)));
 };
 
 export const calculateBatchTotals = (
@@ -490,27 +516,13 @@ export const buildBatchPayload = (batch: BatchValues): InventoryBatchPayload | u
   const quantity = toPayloadNumber(batch.quantity ?? batchRecord.current ?? batchRecord.available);
   const allocated = toPayloadNumber(batch.allocated);
   const normalizeDateForApi = (val?: string) => {
-    if (!val) return undefined;
-    if (val.includes('/')) {
-      const [dd, mm, yyyy] = val.split('/');
-      const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
-      if (!Number.isNaN(parsed.getTime())) {
-        return parsed.toISOString();
-      }
+    const parts = parseInventoryCalendarDateParts(val);
+    if (!parts) return undefined;
+    if (val?.includes('T')) {
+      const instant = new Date(val);
+      if (!Number.isNaN(instant.getTime())) return instant.toISOString();
     }
-    const isoDateMatch = /^(\d{4})-(\d{2})-(\d{2})$/.exec(val);
-    if (isoDateMatch) {
-      const [, yyyy, mm, dd] = isoDateMatch;
-      const parsed = new Date(Date.UTC(Number(yyyy), Number(mm) - 1, Number(dd)));
-      if (!Number.isNaN(parsed.getTime())) {
-        return parsed.toISOString();
-      }
-    }
-    const parsed = new Date(val);
-    if (!Number.isNaN(parsed.getTime())) {
-      return parsed.toISOString();
-    }
-    return undefined;
+    return new Date(Date.UTC(parts.year, parts.month - 1, parts.day)).toISOString();
   };
 
   const normalizedManufacture = normalizeDateForApi(batch.manufactureDate);
@@ -518,10 +530,6 @@ export const buildBatchPayload = (batch: BatchValues): InventoryBatchPayload | u
   const normalizedMinShelfLife = normalizeDateForApi(
     batch.nextRefillDate ?? batch.minShelfLifeAlertDate
   );
-  const manufactureRaw = toStringSafe(batch.manufactureDate);
-  const expiryRaw = toStringSafe(batch.expiryDate);
-  const minShelfRaw = toStringSafe(batch.nextRefillDate ?? batch.minShelfLifeAlertDate);
-
   const payload: InventoryBatchPayload = cleanObject({
     _id: batch._id,
     itemId: batch.itemId,
@@ -531,9 +539,9 @@ export const buildBatchPayload = (batch: BatchValues): InventoryBatchPayload | u
     regulatoryTrackingId: batch.tracking,
     expiryWarningBefore: batch.expiryWarningBefore,
     barcode: batch.barcode,
-    manufactureDate: normalizedManufacture ?? (manufactureRaw || undefined),
-    expiryDate: normalizedExpiry ?? (expiryRaw || undefined),
-    minShelfLifeAlertDate: normalizedMinShelfLife ?? (minShelfRaw || undefined),
+    manufactureDate: normalizedManufacture,
+    expiryDate: normalizedExpiry,
+    minShelfLifeAlertDate: normalizedMinShelfLife,
     quantity,
     allocated,
   });


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Inventory dates represented as midnight UTC can render or reopen one day or month early in browsers west of UTC. Appointment and task slot accessible names add the row hour to the calendar cursor's incidental time, so screen readers can announce a different time from the visible row.

## What is the new behavior?

Inventory calendar values now share strict calendar-part parsing across detail views, compact cards, picker values, and batch serialization. Invalid dates are rejected instead of rolling into another month, while timestamp fields remain timestamp-aware.

Appointment and task slot labels now construct the intended wall-clock time in the configured timezone, independent of the cursor's incidental hour and minute.

Validation:

- Frontend TypeScript: passed.
- Frontend lint: passed with one pre-existing warning outside the changed files.
- Focused Jest: 8 suites and 223 tests passed.
- Full pre-push monorepo lint and type-check: passed.
- Browser QA in Chromium with `America/Los_Angeles`: March 1 remained March 1 in the picker and March 2026 in the compact card; appointment and task labels matched their visible row times.
- Mutation checks: restoring elapsed-hour label arithmetic failed the appointment regression test; restoring UTC picker construction failed the inventory regression test under `America/Los_Angeles`.

## Related Issue(s)

Fixes #3189
Fixes #3190
