### PR TITLE
fix(frontend): improve docs keyboard accessibility

### DIFF
--- a/apps/frontend/src/app/__tests__/features/docs/DocsSearch.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/docs/DocsSearch.test.tsx
@@ -118,4 +118,80 @@ describe('DocsSearch', () => {
     });
     expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
   });
+
+  it('selects results with the keyboard and activates the selected link', async () => {
+    mockIndex();
+    render(<DocsSearch />);
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.focus(input);
+    });
+    fireEvent.change(input, { target: { value: 'api' } });
+
+    const option = await screen.findByRole('option', { name: /User API/ });
+    const click = jest.spyOn(option, 'click').mockImplementation(() => undefined);
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    expect(option).toHaveAttribute('aria-selected', 'true');
+    expect(input).toHaveAttribute('aria-activedescendant', option.id);
+
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(click).toHaveBeenCalledTimes(1);
+  });
+
+  it('clamps arrow navigation and resets selection when the query changes', async () => {
+    mockIndex();
+    render(<DocsSearch />);
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.focus(input);
+    });
+    fireEvent.change(input, { target: { value: 'i' } });
+    const options = await screen.findAllByRole('option');
+
+    fireEvent.keyDown(input, { key: 'End' });
+    expect(options.at(-1)).toHaveAttribute('aria-selected', 'true');
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+    expect(options.at(-1)).toHaveAttribute('aria-selected', 'true');
+    fireEvent.keyDown(input, { key: 'Home' });
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+    fireEvent.keyDown(input, { key: 'ArrowUp' });
+    expect(options[0]).toHaveAttribute('aria-selected', 'true');
+
+    fireEvent.change(input, { target: { value: 'user' } });
+    await waitFor(() => expect(input).not.toHaveAttribute('aria-activedescendant'));
+    expect(screen.getByRole('option')).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('retries a failed load once and preserves the query', async () => {
+    global.fetch = jest
+      .fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, json: async () => INDEX }) as unknown as typeof fetch;
+
+    render(<DocsSearch />);
+    const input = screen.getByRole('combobox');
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: 'user' } });
+    const retry = await screen.findByRole('button', { name: 'Retry' });
+    fireEvent.click(retry);
+
+    expect(await screen.findByRole('option', { name: /User API/ })).toBeInTheDocument();
+    expect(input).toHaveValue('user');
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('deduplicates repeated load attempts while a request is pending', () => {
+    global.fetch = jest
+      .fn()
+      .mockReturnValue(new Promise(() => undefined)) as unknown as typeof fetch;
+    render(<DocsSearch />);
+    const input = screen.getByRole('combobox');
+
+    fireEvent.focus(input);
+    fireEvent.blur(input);
+    fireEvent.focus(input);
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/frontend/src/app/__tests__/features/docs/DocsShell.test.tsx
+++ b/apps/frontend/src/app/__tests__/features/docs/DocsShell.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import DocsShell from '@/app/features/docs/DocsShell';
+import SkipLink from '@/app/ui/layout/SkipLink';
 import { loadCorpus } from '@/app/features/docs/corpus';
 import { renderDoc } from '@/app/features/docs/render';
 import type { NavNode } from '@/app/features/docs/docsNav';
@@ -71,6 +72,31 @@ describe('DocsShell', () => {
     await shell('x');
     expect(screen.getByRole('link', { name: 'Overview' })).toBeInTheDocument();
     expect(screen.getByRole('combobox', { name: 'Search the documentation' })).toBeInTheDocument();
+  });
+
+  it('provides the global skip link with one focusable main-content target', async () => {
+    const { container } = render(
+      <>
+        <SkipLink />
+        <DocsShell
+          nav={NAV}
+          toc={TOC}
+          title="Getting Started"
+          breadcrumb={['Docs', 'Getting Started']}
+          tree={await treeFor('x')}
+          editUrl="https://github.com/YosemiteCrew/Yosemite-Crew/edit/dev/apps/frontend/content/docs/test.md"
+        />
+      </>
+    );
+    expect(screen.getByRole('link', { name: 'Skip to main content' })).toHaveAttribute(
+      'href',
+      '#main-content'
+    );
+    const target = container.querySelectorAll('#main-content');
+
+    expect(target).toHaveLength(1);
+    expect(target[0]).toHaveAttribute('tabindex', '-1');
+    expect(target[0]?.tagName).toBe('MAIN');
   });
 
   it('renders the table of contents, nesting depth-3 entries', async () => {

--- a/apps/frontend/src/app/features/docs/DocsSearch.tsx
+++ b/apps/frontend/src/app/features/docs/DocsSearch.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useEffect, useId, useRef, useState } from 'react';
+import type { KeyboardEvent } from 'react';
 import type { SearchDoc } from './searchIndex';
 
 /**
@@ -48,18 +49,32 @@ export default function DocsSearch() {
   const [query, setQuery] = useState('');
   const [docs, setDocs] = useState<SearchDoc[] | null>(null);
   const [loadFailed, setLoadFailed] = useState(false);
+  const [activeIndex, setActiveIndex] = useState(-1);
   const containerRef = useRef<HTMLDivElement>(null);
+  const loadPromiseRef = useRef<Promise<void> | null>(null);
+  const resultRefs = useRef<Array<HTMLAnchorElement | null>>([]);
   const listId = useId();
 
   const load = () => {
-    if (docs || loadFailed) return;
-    fetch(INDEX_URL)
+    if (docs || loadPromiseRef.current) return loadPromiseRef.current;
+    setLoadFailed(false);
+    const loadPromise = fetch(INDEX_URL)
       .then((response) => {
         if (!response.ok) throw new Error(String(response.status));
         return response.json();
       })
-      .then((data: SearchDoc[]) => setDocs(data))
-      .catch(() => setLoadFailed(true));
+      .then((data: SearchDoc[]) => {
+        setDocs(data);
+        setActiveIndex(-1);
+      })
+      .catch(() => {
+        setLoadFailed(true);
+      })
+      .finally(() => {
+        loadPromiseRef.current = null;
+      });
+    loadPromiseRef.current = loadPromise;
+    return loadPromise;
   };
 
   // Clicking away closes the results without clearing what was typed.
@@ -75,6 +90,33 @@ export default function DocsSearch() {
 
   const results = docs ? rank(docs, query) : [];
   const showPanel = open && query.trim().length > 0;
+  const activeOptionId = activeIndex >= 0 ? `${listId}-option-${activeIndex}` : undefined;
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Escape') {
+      setOpen(false);
+      setActiveIndex(-1);
+      return;
+    }
+    if (!showPanel || results.length === 0) return;
+
+    let nextIndex: number | null = null;
+    if (event.key === 'ArrowDown') nextIndex = Math.min(activeIndex + 1, results.length - 1);
+    else if (event.key === 'ArrowUp')
+      nextIndex = Math.max(activeIndex < 0 ? 0 : activeIndex - 1, 0);
+    else if (event.key === 'Home') nextIndex = 0;
+    else if (event.key === 'End') nextIndex = results.length - 1;
+    else if (event.key === 'Enter' && activeIndex >= 0) {
+      event.preventDefault();
+      resultRefs.current[activeIndex]?.click();
+      return;
+    }
+
+    if (nextIndex !== null) {
+      event.preventDefault();
+      setActiveIndex(nextIndex);
+    }
+  };
 
   return (
     <div className="DocsSearch" ref={containerRef}>
@@ -85,6 +127,7 @@ export default function DocsSearch() {
         aria-label="Search the documentation"
         aria-controls={listId}
         aria-expanded={showPanel}
+        aria-activedescendant={activeOptionId}
         role="combobox"
         value={query}
         onFocus={() => {
@@ -93,28 +136,37 @@ export default function DocsSearch() {
         }}
         onChange={(event) => {
           setQuery(event.target.value);
+          setActiveIndex(-1);
           setOpen(true);
         }}
+        onKeyDown={handleKeyDown}
       />
 
       {showPanel && (
         <div className="DocsSearchPanel" id={listId} role="listbox">
           {loadFailed && (
-            <p className="DocsSearchEmpty">
-              Search is unavailable right now. Use the sidebar to browse.
-            </p>
+            <div className="DocsSearchEmpty">
+              <span>Search is unavailable right now. Use the sidebar to browse.</span>
+              <button type="button" className="DocsSearchRetry" onClick={() => void load()}>
+                Retry
+              </button>
+            </div>
           )}
           {!loadFailed && !docs && <p className="DocsSearchEmpty">Loading…</p>}
           {!loadFailed && docs && results.length === 0 && (
             <p className="DocsSearchEmpty">No matches for “{query}”.</p>
           )}
-          {results.map((result) => (
+          {results.map((result, index) => (
             <Link
               key={result.href}
+              id={`${listId}-option-${index}`}
               href={result.href}
               className="DocsSearchResult"
               role="option"
-              aria-selected="false"
+              aria-selected={index === activeIndex}
+              ref={(element) => {
+                resultRefs.current[index] = element;
+              }}
               onClick={() => setOpen(false)}
             >
               <span className="DocsSearchResultTitle">{result.title}</span>

--- a/apps/frontend/src/app/features/docs/DocsShell.tsx
+++ b/apps/frontend/src/app/features/docs/DocsShell.tsx
@@ -74,7 +74,7 @@ export default function DocsShell({
         <div className="DocsLayout">
           <DocsSidebar nav={nav} />
 
-          <main className="DocsMain" id="docs-content">
+          <main className="DocsMain" id="main-content" tabIndex={-1}>
             <nav className="DocsBreadcrumb" aria-label="Breadcrumb">
               {breadcrumb.map((crumb, index) => (
                 <span key={crumb}>

--- a/apps/frontend/src/app/features/docs/docs.css
+++ b/apps/frontend/src/app/features/docs/docs.css
@@ -396,6 +396,23 @@
   color: var(--color-text-tertiary);
 }
 
+.DocsSearchRetry {
+  margin-top: 8px;
+  border: 0;
+  padding: 0;
+  color: var(--blue-text);
+  background: transparent;
+  font: inherit;
+  font-weight: 700;
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.DocsSearchRetry:focus-visible {
+  outline: 2px solid var(--blue-text);
+  outline-offset: 3px;
+}
+
 .DocsSearchResult {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
## PR Checklist

- [x] The PR title follows our guidelines: https://github.com/YosemiteCrew/Yosemite-Crew/blob/main/CONTRIBUTING.md#commit-message-convention.
- [x] There is an issue for the bug/feature this PR is for. To avoid wasting your time, it's best to open a suggestion issue first and wait for approval before working on it.
- [x] All existing tests and lints pass.

## What is the current behavior?

Documentation search exposes combobox semantics without keyboard result selection, cannot recover from a transient index failure, and the global skip link points to a missing target.

## What is the new behavior?

Search now supports Arrow Up/Down, Home, End, Enter, and Escape while keeping focus in the input and exposing exactly one active option. A failed index request offers an accessible Retry action, preserves the query, deduplicates in-flight requests, and reuses successful cached data. The docs article main landmark now matches the global skip link and accepts programmatic focus.

The browser check also caught and removed hover-driven active selection that could make the first Arrow Down skip to the second result after Retry changed the panel layout.

Validation:

- Frontend TypeScript: passed.
- Focused strict lint: passed.
- Focused Jest: 2 suites and 27 tests passed.
- Full pre-push monorepo lint and type-check: passed.
- Chromium QA against the real docs route: skip target focused, failed request retried once, exactly one option selected, and Enter opened the first Inventory API result.
- Mutation checks: removing keyboard handling, restoring the permanent failure guard, and removing the skip target produced four intended test failures.

## Related Issue(s)

Fixes #3191
Fixes #3192
Fixes #3193
